### PR TITLE
feat: add GitHubIssueService module (#15)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,9 +15,15 @@ val ktorVersion = "3.4.1"
 val exposedVersion = "0.61.0"
 
 dependencies {
-    // Ktor (compileOnly — apper har sin egen versjon)
+    // Ktor server (compileOnly — apper har sin egen versjon)
     compileOnly("io.ktor:ktor-server-core:$ktorVersion")
     compileOnly("io.ktor:ktor-server-status-pages:$ktorVersion")
+
+    // Ktor client (compileOnly — for GitHubIssueService)
+    compileOnly("io.ktor:ktor-client-core:$ktorVersion")
+    compileOnly("io.ktor:ktor-client-cio:$ktorVersion")
+    compileOnly("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+    compileOnly("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
 
     // Exposed (compileOnly — apper har sin egen versjon)
     compileOnly("org.jetbrains.exposed:exposed-core:$exposedVersion")
@@ -33,6 +39,11 @@ dependencies {
     // Test
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.14.3")
+    testImplementation("io.ktor:ktor-client-core:$ktorVersion")
+    testImplementation("io.ktor:ktor-client-cio:$ktorVersion")
+    testImplementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+    testImplementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
 }
 
 java {

--- a/src/main/kotlin/no/grunnmur/GitHubIssueService.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueService.kt
@@ -1,0 +1,129 @@
+package no.grunnmur
+
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Service for aa opprette GitHub Issues via API.
+ * All input saniteres via [InputSanitizer].
+ */
+class GitHubIssueService(private val config: Config) {
+
+    data class Config(
+        val token: String,
+        val repo: String,
+        val uploadDir: String? = null,
+        val publicBaseUrl: String? = null
+    )
+
+    @Serializable
+    data class CreateIssueRequest(
+        val title: String,
+        val body: String,
+        val labels: List<String> = emptyList()
+    )
+
+    @Serializable
+    data class GitHubIssueResponse(
+        val number: Int,
+        val html_url: String
+    )
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val client by lazy {
+        HttpClient(CIO) {
+            install(ContentNegotiation) {
+                json(this@GitHubIssueService.json)
+            }
+        }
+    }
+
+    /**
+     * Bygger Markdown-body for en GitHub Issue.
+     * All input saniteres via [InputSanitizer].
+     */
+    fun buildBody(
+        senderName: String,
+        senderEmail: String,
+        description: String,
+        consoleLogs: String? = null,
+        imageFilenames: List<String>? = null
+    ): String = buildString {
+        val safeName = InputSanitizer.sanitize(senderName, InputSanitizer.MAX_TITLE_LENGTH)
+        val safeEmail = InputSanitizer.sanitize(senderEmail, InputSanitizer.MAX_TITLE_LENGTH)
+        val safeDescription = InputSanitizer.sanitize(description, InputSanitizer.MAX_DESCRIPTION_LENGTH)
+
+        appendLine("**Meldt av**: $safeName ($safeEmail)")
+        appendLine()
+        appendLine(safeDescription)
+
+        if (!consoleLogs.isNullOrBlank()) {
+            val safeLogs = InputSanitizer.sanitize(consoleLogs, InputSanitizer.MAX_LOGS_LENGTH)
+            appendLine()
+            appendLine("<details><summary>Konsoll-logg</summary>")
+            appendLine()
+            appendLine("```")
+            appendLine(safeLogs)
+            appendLine("```")
+            appendLine()
+            appendLine("</details>")
+        }
+
+        if (!imageFilenames.isNullOrEmpty() && config.publicBaseUrl != null) {
+            val dir = config.uploadDir?.let { "$it/" } ?: ""
+            val baseUrl = config.publicBaseUrl.trimEnd('/')
+            appendLine()
+            appendLine("### Vedlegg")
+            for (filename in imageFilenames) {
+                val safeFilename = InputSanitizer.sanitize(filename, InputSanitizer.MAX_TITLE_LENGTH)
+                appendLine("![${safeFilename}](${baseUrl}/${dir}${safeFilename})")
+            }
+        }
+    }.trimEnd()
+
+    /**
+     * Oppretter en GitHub Issue via API.
+     * Returnerer [GitHubIssueResponse] med issue-nummer og URL.
+     */
+    suspend fun createIssue(
+        title: String,
+        senderName: String,
+        senderEmail: String,
+        description: String,
+        consoleLogs: String? = null,
+        imageFilenames: List<String>? = null,
+        labels: List<String> = emptyList()
+    ): GitHubIssueResponse {
+        val safeTitle = InputSanitizer.sanitize(title, InputSanitizer.MAX_TITLE_LENGTH)
+        val body = buildBody(senderName, senderEmail, description, consoleLogs, imageFilenames)
+
+        val request = CreateIssueRequest(
+            title = safeTitle,
+            body = body,
+            labels = labels
+        )
+
+        val response = client.post("https://api.github.com/repos/${config.repo}/issues") {
+            header("Authorization", "Bearer ${config.token}")
+            header("Accept", "application/vnd.github+json")
+            header("X-GitHub-Api-Version", "2022-11-28")
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+
+        if (!response.status.isSuccess()) {
+            val errorBody = response.bodyAsText()
+            throw RuntimeException("Kunne ikke opprette GitHub Issue: ${response.status} — $errorBody")
+        }
+
+        return json.decodeFromString<GitHubIssueResponse>(response.bodyAsText())
+    }
+}

--- a/src/test/kotlin/no/grunnmur/GitHubIssueServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/GitHubIssueServiceTest.kt
@@ -1,0 +1,173 @@
+package no.grunnmur
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+class GitHubIssueServiceTest {
+
+    private val config = GitHubIssueService.Config(
+        token = "test-token",
+        repo = "TestOrg/test-repo",
+        uploadDir = "uploads",
+        publicBaseUrl = "https://example.com"
+    )
+
+    private val service = GitHubIssueService(config)
+
+    @Test
+    fun `buildBody inkluderer avsender-info`() {
+        val body = service.buildBody(
+            senderName = "Ola Nordmann",
+            senderEmail = "ola@example.com",
+            description = "Noe er galt med systemet"
+        )
+
+        assertContains(body, "Ola Nordmann")
+        assertContains(body, "ola@example.com")
+        assertContains(body, "Noe er galt med systemet")
+    }
+
+    @Test
+    fun `buildBody saniterer all input via InputSanitizer`() {
+        val body = service.buildBody(
+            senderName = "<script>alert('xss')</script>Ola",
+            senderEmail = "ola@example.com",
+            description = "Sjekk [denne linken](https://evil.com) og @admin"
+        )
+
+        // Script-tags og markdown-lenker skal vaere fjernet
+        assertFalse(body.contains("<script>"))
+        assertFalse(body.contains("</script>"))
+        assertFalse(body.contains("[denne linken](https://evil.com)"))
+        // Mentions skal vaere beskyttet
+        assertContains(body, "`@admin`")
+    }
+
+    @Test
+    fun `buildBody maskerer secrets i beskrivelse`() {
+        val body = service.buildBody(
+            senderName = "Ola",
+            senderEmail = "ola@example.com",
+            description = "Token: ghp_abc123def456ghi789jkl012mno345"
+        )
+
+        assertFalse(body.contains("ghp_abc123def456ghi789jkl012mno345"))
+        assertContains(body, "[MASKERT]")
+    }
+
+    @Test
+    fun `buildBody inkluderer konsoll-logg i sammenleggbar seksjon`() {
+        val body = service.buildBody(
+            senderName = "Ola",
+            senderEmail = "ola@example.com",
+            description = "Feilmelding",
+            consoleLogs = "Error: Something went wrong\nat line 42"
+        )
+
+        assertContains(body, "<details>")
+        assertContains(body, "</details>")
+        assertContains(body, "Konsoll-logg")
+        assertContains(body, "Error: Something went wrong")
+    }
+
+    @Test
+    fun `buildBody utelater konsoll-seksjon naar logs er null`() {
+        val body = service.buildBody(
+            senderName = "Ola",
+            senderEmail = "ola@example.com",
+            description = "Feilmelding"
+        )
+
+        assertFalse(body.contains("<details>"))
+        assertFalse(body.contains("Konsoll-logg"))
+    }
+
+    @Test
+    fun `buildBody inkluderer bilde-lenker`() {
+        val body = service.buildBody(
+            senderName = "Ola",
+            senderEmail = "ola@example.com",
+            description = "Se vedlegg",
+            imageFilenames = listOf("screenshot1.png", "screenshot2.jpg")
+        )
+
+        assertContains(body, "![screenshot1.png](https://example.com/uploads/screenshot1.png)")
+        assertContains(body, "![screenshot2.jpg](https://example.com/uploads/screenshot2.jpg)")
+        assertContains(body, "Vedlegg")
+    }
+
+    @Test
+    fun `buildBody utelater vedlegg-seksjon naar ingen bilder`() {
+        val body = service.buildBody(
+            senderName = "Ola",
+            senderEmail = "ola@example.com",
+            description = "Ingen vedlegg"
+        )
+
+        assertFalse(body.contains("Vedlegg"))
+    }
+
+    @Test
+    fun `buildBody saniterer konsoll-logg`() {
+        val body = service.buildBody(
+            senderName = "Ola",
+            senderEmail = "ola@example.com",
+            description = "Feil",
+            consoleLogs = "Token: ghp_abc123def456ghi789jkl012mno345 ble lekket"
+        )
+
+        assertFalse(body.contains("ghp_abc123def456ghi789jkl012mno345"))
+    }
+
+    @Test
+    fun `buildBody trunkerer lang beskrivelse`() {
+        val longDescription = "A".repeat(3000)
+        val body = service.buildBody(
+            senderName = "Ola",
+            senderEmail = "ola@example.com",
+            description = longDescription
+        )
+
+        // Beskrivelsen skal vaere trunkert til MAX_DESCRIPTION_LENGTH
+        assertFalse(body.contains("A".repeat(3000)))
+    }
+
+    @Test
+    fun `buildBody trunkerer lange konsoll-logger`() {
+        val longLogs = "X".repeat(15000)
+        val body = service.buildBody(
+            senderName = "Ola",
+            senderEmail = "ola@example.com",
+            description = "Feil",
+            consoleLogs = longLogs
+        )
+
+        assertFalse(body.contains("X".repeat(15000)))
+    }
+
+    @Test
+    fun `buildBody haandterer tom bildliste`() {
+        val body = service.buildBody(
+            senderName = "Ola",
+            senderEmail = "ola@example.com",
+            description = "Test",
+            imageFilenames = emptyList()
+        )
+
+        assertFalse(body.contains("Vedlegg"))
+    }
+
+    @Test
+    fun `buildBody saniterer bilde-filnavn`() {
+        val body = service.buildBody(
+            senderName = "Ola",
+            senderEmail = "ola@example.com",
+            description = "Test",
+            imageFilenames = listOf("<script>alert(1)</script>.png")
+        )
+
+        assertFalse(body.contains("<script>"))
+    }
+}


### PR DESCRIPTION
Fixes #15

## Summary
- Adds `GitHubIssueService.kt` — configurable service for creating GitHub Issues via API
- Builds Markdown body with sender info, optional console logs (collapsible `<details>`), and image links
- All input sanitized via `InputSanitizer`
- Adds ktor-client dependencies (compileOnly + testImplementation)
- 12 tests covering body formatting, sanitization, truncation, and edge cases

## Test plan
- [x] CI green — all 12 new tests pass
- [x] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)