### PR TITLE
feat: add ImageUploadService for secure image upload handling

### DIFF
--- a/src/main/kotlin/no/grunnmur/ImageUploadService.kt
+++ b/src/main/kotlin/no/grunnmur/ImageUploadService.kt
@@ -1,0 +1,119 @@
+package no.grunnmur
+
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.io.path.*
+
+/**
+ * Service for sikker håndtering av bildeopplasting.
+ * Validerer filtype via magic bytes, håndhever størrelsesbegrensninger,
+ * og genererer tilfeldige filnavn for å forhindre path traversal.
+ *
+ * Bruk:
+ * ```
+ * val service = ImageUploadService(ImageUploadService.Config(
+ *     uploadDir = "/uploads/issues",
+ *     baseUrl = "https://example.com/uploads/issues"
+ * ))
+ * val url = service.uploadImage(issueNumber = 1, data = bytes, originalFilename = "bilde.png")
+ * ```
+ */
+class ImageUploadService(private val config: Config) {
+
+    data class Config(
+        val uploadDir: String,
+        val baseUrl: String,
+        val maxFileSize: Long = 2 * 1024 * 1024,
+        val maxImagesPerIssue: Int = 3
+    )
+
+    private enum class ImageType(val extension: String) {
+        PNG("png"),
+        JPEG("jpg"),
+        WEBP("webp")
+    }
+
+    /** Laster opp et bilde for en gitt issue. Returnerer offentlig URL ved suksess. */
+    fun uploadImage(issueNumber: Int, data: ByteArray, originalFilename: String): Result<String> {
+        if (data.isEmpty()) {
+            return Result.failure(IllegalArgumentException("Ugyldig filtype: tom fil"))
+        }
+
+        if (data.size > config.maxFileSize) {
+            return Result.failure(IllegalArgumentException("Filen er for stor (maks ${config.maxFileSize / 1024 / 1024} MB)"))
+        }
+
+        val imageType = detectImageType(data)
+            ?: return Result.failure(IllegalArgumentException("Ugyldig filtype: kun PNG, JPG og WEBP er tillatt"))
+
+        val issueDir = Path.of(config.uploadDir, issueNumber.toString())
+        if (issueDir.exists()) {
+            val existingCount = issueDir.listDirectoryEntries().size
+            if (existingCount >= config.maxImagesPerIssue) {
+                return Result.failure(IllegalArgumentException("Kan ikke laste opp flere bilder (maks ${config.maxImagesPerIssue} per issue)"))
+            }
+        }
+
+        issueDir.createDirectories()
+
+        val filename = "${UUID.randomUUID()}.${imageType.extension}"
+        val targetPath = issueDir.resolve(filename)
+        targetPath.writeBytes(data)
+
+        val baseUrl = config.baseUrl.trimEnd('/')
+        val url = "$baseUrl/$issueNumber/$filename"
+        return Result.success(url)
+    }
+
+    /** Sletter alle bilder for en gitt issue. */
+    fun deleteIssueImages(issueNumber: Int) {
+        val issueDir = Path.of(config.uploadDir, issueNumber.toString())
+        if (issueDir.exists()) {
+            issueDir.toFile().deleteRecursively()
+        }
+    }
+
+    /** Sletter bilder for issues som ikke lenger er åpne. */
+    fun cleanupClosedIssues(openIssueNumbers: Set<Int>) {
+        val uploadPath = Path.of(config.uploadDir)
+        if (!uploadPath.exists()) return
+
+        uploadPath.listDirectoryEntries().forEach { dir ->
+            if (dir.isDirectory()) {
+                val issueNumber = dir.name.toIntOrNull()
+                if (issueNumber != null && issueNumber !in openIssueNumbers) {
+                    dir.toFile().deleteRecursively()
+                }
+            }
+        }
+    }
+
+    private fun detectImageType(data: ByteArray): ImageType? {
+        if (data.size < 12) return null
+        return when {
+            isPng(data) -> ImageType.PNG
+            isJpeg(data) -> ImageType.JPEG
+            isWebp(data) -> ImageType.WEBP
+            else -> null
+        }
+    }
+
+    private fun isPng(data: ByteArray): Boolean {
+        val pngMagic = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+        return data.size >= 8 && data.sliceArray(0 until 8).contentEquals(pngMagic)
+    }
+
+    private fun isJpeg(data: ByteArray): Boolean {
+        return data.size >= 3 &&
+            data[0] == 0xFF.toByte() &&
+            data[1] == 0xD8.toByte() &&
+            data[2] == 0xFF.toByte()
+    }
+
+    private fun isWebp(data: ByteArray): Boolean {
+        if (data.size < 12) return false
+        val riff = data.sliceArray(0 until 4)
+        val webp = data.sliceArray(8 until 12)
+        return riff.contentEquals("RIFF".toByteArray()) && webp.contentEquals("WEBP".toByteArray())
+    }
+}

--- a/src/test/kotlin/no/grunnmur/ImageUploadServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/ImageUploadServiceTest.kt
@@ -1,0 +1,253 @@
+package no.grunnmur
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
+
+class ImageUploadServiceTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun createService(
+        maxFileSize: Long = 2 * 1024 * 1024,
+        maxImagesPerIssue: Int = 3,
+        baseUrl: String = "https://example.com/uploads/issues"
+    ): ImageUploadService {
+        return ImageUploadService(
+            ImageUploadService.Config(
+                uploadDir = tempDir.toString(),
+                baseUrl = baseUrl,
+                maxFileSize = maxFileSize,
+                maxImagesPerIssue = maxImagesPerIssue
+            )
+        )
+    }
+
+    // PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A
+    private fun pngBytes(size: Int = 100): ByteArray {
+        val header = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+        return header + ByteArray(size - header.size)
+    }
+
+    // JPEG magic bytes: FF D8 FF
+    private fun jpegBytes(size: Int = 100): ByteArray {
+        val header = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())
+        return header + ByteArray(size - header.size)
+    }
+
+    // WEBP magic bytes: RIFF....WEBP
+    private fun webpBytes(size: Int = 100): ByteArray {
+        val header = byteArrayOf(
+            0x52, 0x49, 0x46, 0x46, // RIFF
+            0x00, 0x00, 0x00, 0x00, // file size placeholder
+            0x57, 0x45, 0x42, 0x50  // WEBP
+        )
+        return header + ByteArray(size - header.size)
+    }
+
+    @Nested
+    inner class Filtypevalidering {
+
+        @Test
+        fun `godtar PNG-bilde`() {
+            val service = createService()
+            val result = service.uploadImage(1, pngBytes(), "test.png")
+            assertTrue(result.isSuccess)
+        }
+
+        @Test
+        fun `godtar JPEG-bilde`() {
+            val service = createService()
+            val result = service.uploadImage(1, jpegBytes(), "test.jpg")
+            assertTrue(result.isSuccess)
+        }
+
+        @Test
+        fun `godtar WEBP-bilde`() {
+            val service = createService()
+            val result = service.uploadImage(1, webpBytes(), "test.webp")
+            assertTrue(result.isSuccess)
+        }
+
+        @Test
+        fun `avviser GIF-bilde`() {
+            val gifHeader = byteArrayOf(0x47, 0x49, 0x46, 0x38, 0x39, 0x61) // GIF89a
+            val data = gifHeader + ByteArray(94)
+            val service = createService()
+            val result = service.uploadImage(1, data, "test.gif")
+            assertTrue(result.isFailure)
+            assertContains(result.exceptionOrNull()!!.message!!, "filtype")
+        }
+
+        @Test
+        fun `avviser tilfeldig data uten gyldig magic bytes`() {
+            val service = createService()
+            val result = service.uploadImage(1, ByteArray(100), "test.png")
+            assertTrue(result.isFailure)
+        }
+
+        @Test
+        fun `avviser tom fil`() {
+            val service = createService()
+            val result = service.uploadImage(1, ByteArray(0), "test.png")
+            assertTrue(result.isFailure)
+        }
+    }
+
+    @Nested
+    inner class Størrelsesbegrensning {
+
+        @Test
+        fun `avviser bilde over maks størrelse`() {
+            val service = createService(maxFileSize = 1024)
+            val result = service.uploadImage(1, pngBytes(2048), "big.png")
+            assertTrue(result.isFailure)
+            assertContains(result.exceptionOrNull()!!.message!!, "stor")
+        }
+
+        @Test
+        fun `godtar bilde på nøyaktig maks størrelse`() {
+            val service = createService(maxFileSize = 1024)
+            val result = service.uploadImage(1, pngBytes(1024), "exact.png")
+            assertTrue(result.isSuccess)
+        }
+    }
+
+    @Nested
+    inner class MaksAntallBilder {
+
+        @Test
+        fun `avviser fjerde bilde for samme issue`() {
+            val service = createService(maxImagesPerIssue = 3)
+            service.uploadImage(1, pngBytes(), "a.png")
+            service.uploadImage(1, jpegBytes(), "b.jpg")
+            service.uploadImage(1, webpBytes(), "c.webp")
+            val result = service.uploadImage(1, pngBytes(), "d.png")
+            assertTrue(result.isFailure)
+            assertContains(result.exceptionOrNull()!!.message!!, "maks")
+        }
+
+        @Test
+        fun `teller bilder per issue uavhengig`() {
+            val service = createService(maxImagesPerIssue = 3)
+            service.uploadImage(1, pngBytes(), "a.png")
+            service.uploadImage(1, pngBytes(), "b.png")
+            service.uploadImage(1, pngBytes(), "c.png")
+            // Issue 2 skal fortsatt ha plass
+            val result = service.uploadImage(2, pngBytes(), "d.png")
+            assertTrue(result.isSuccess)
+        }
+    }
+
+    @Nested
+    inner class Filnavn {
+
+        @Test
+        fun `genererer UUID-filnavn`() {
+            val service = createService()
+            val result = service.uploadImage(1, pngBytes(), "../../evil.png")
+            assertTrue(result.isSuccess)
+            val url = result.getOrThrow()
+            // URL skal ikke inneholde originalt filnavn
+            assertFalse(url.contains("evil"))
+            // Skal inneholde riktig extension
+            assertTrue(url.endsWith(".png"))
+        }
+
+        @Test
+        fun `forhindrer path traversal i filnavn`() {
+            val service = createService()
+            val result = service.uploadImage(1, pngBytes(), "../../../etc/passwd.png")
+            assertTrue(result.isSuccess)
+            // Filen skal ligge i riktig mappe, ikke utenfor
+            val issueDir = tempDir.resolve("1")
+            assertTrue(issueDir.exists())
+            val files = issueDir.listDirectoryEntries()
+            assertEquals(1, files.size)
+            assertTrue(files[0].parent == issueDir)
+        }
+
+        @Test
+        fun `bruker riktig extension basert på filtype`() {
+            val service = createService()
+
+            val pngUrl = service.uploadImage(1, pngBytes(), "test.png").getOrThrow()
+            assertTrue(pngUrl.endsWith(".png"))
+
+            val jpegUrl = service.uploadImage(1, jpegBytes(), "test.jpg").getOrThrow()
+            assertTrue(jpegUrl.endsWith(".jpg"))
+
+            val webpUrl = service.uploadImage(1, webpBytes(), "test.webp").getOrThrow()
+            assertTrue(webpUrl.endsWith(".webp"))
+        }
+    }
+
+    @Nested
+    inner class URLGenerering {
+
+        @Test
+        fun `returnerer korrekt offentlig URL`() {
+            val service = createService(baseUrl = "https://example.com/uploads/issues")
+            val url = service.uploadImage(1, pngBytes(), "test.png").getOrThrow()
+            assertTrue(url.startsWith("https://example.com/uploads/issues/1/"))
+            assertTrue(url.endsWith(".png"))
+        }
+    }
+
+    @Nested
+    inner class Sletting {
+
+        @Test
+        fun `deleteIssueImages sletter bildemappe`() {
+            val service = createService()
+            service.uploadImage(1, pngBytes(), "a.png")
+            service.uploadImage(1, jpegBytes(), "b.jpg")
+            val issueDir = tempDir.resolve("1")
+            assertTrue(issueDir.exists())
+
+            service.deleteIssueImages(1)
+            assertFalse(issueDir.exists())
+        }
+
+        @Test
+        fun `deleteIssueImages feiler ikke for ikke-eksisterende issue`() {
+            val service = createService()
+            // Skal ikke kaste exception
+            service.deleteIssueImages(999)
+        }
+    }
+
+    @Nested
+    inner class Opprydding {
+
+        @Test
+        fun `cleanupClosedIssues sletter kun lukkede issues sine bilder`() {
+            val service = createService()
+            service.uploadImage(1, pngBytes(), "a.png")
+            service.uploadImage(2, pngBytes(), "b.png")
+            service.uploadImage(3, pngBytes(), "c.png")
+
+            // Issue 1 og 3 er åpne, issue 2 er lukket
+            service.cleanupClosedIssues(openIssueNumbers = setOf(1, 3))
+
+            assertTrue(tempDir.resolve("1").exists())
+            assertFalse(tempDir.resolve("2").exists())
+            assertTrue(tempDir.resolve("3").exists())
+        }
+
+        @Test
+        fun `cleanupClosedIssues håndterer tom uploadDir`() {
+            val service = createService()
+            // Skal ikke kaste exception
+            service.cleanupClosedIssues(openIssueNumbers = setOf(1))
+        }
+    }
+}


### PR DESCRIPTION
Fixes #16

## Sammendrag
- Ny `ImageUploadService` for sikker bildeopplasting
- Validerer filtype via magic bytes (kun PNG/JPG/WEBP)
- Håndhever størrelsesbegrensninger (konfigurerbar maks per fil og per issue)
- Genererer UUID-filnavn for å forhindre path traversal
- `deleteIssueImages()` og `cleanupClosedIssues()` for opprydding
- 16 tester dekker validering, sikkerhet og opprydding