### PR TITLE
feat: add GitHubIssueRoutes for issue creation and webhook (closes #17)

### DIFF
--- a/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
@@ -1,0 +1,170 @@
+package no.grunnmur
+
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.security.MessageDigest
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Konfigurasjon for issue-ruter.
+ */
+data class GitHubIssueRoutesConfig(
+    val issueService: GitHubIssueService,
+    val imageService: ImageUploadService?,
+    val rateLimiter: RateLimiter,
+    val webhookSecret: String
+)
+
+@Serializable
+internal data class WebhookPayload(
+    val action: String = "",
+    val issue: WebhookIssue? = null
+)
+
+@Serializable
+internal data class WebhookIssue(
+    val number: Int
+)
+
+@Serializable
+data class CreateIssueResponse(
+    val issueNumber: Int,
+    val issueUrl: String,
+    val imageUrls: List<String> = emptyList()
+)
+
+private val webhookJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * Verifiserer GitHub webhook-signatur (HMAC-SHA256).
+ * Sammenligner signaturen med beregnet HMAC i konstant tid.
+ */
+fun verifyWebhookSignature(payload: ByteArray, signature: String, secret: String): Boolean {
+    if (!signature.startsWith("sha256=")) return false
+
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(SecretKeySpec(secret.toByteArray(), "HmacSHA256"))
+    val expected = "sha256=" + mac.doFinal(payload).joinToString("") { "%02x".format(it) }
+
+    return MessageDigest.isEqual(expected.toByteArray(), signature.toByteArray())
+}
+
+/**
+ * Parser webhook-payload og returnerer (action, issueNumber) eller null.
+ */
+fun parseWebhookAction(payload: String): Pair<String, Int>? {
+    return try {
+        val parsed = webhookJson.decodeFromString<WebhookPayload>(payload)
+        val issue = parsed.issue ?: return null
+        Pair(parsed.action, issue.number)
+    } catch (_: Exception) {
+        null
+    }
+}
+
+/**
+ * Registrerer ruter for issue-opprettelse og GitHub webhook.
+ *
+ * - `POST /api/issues` — Oppretter issue med valgfrie bilder (multipart)
+ * - `POST /api/issues/webhook` — GitHub webhook for opprydding ved issue-lukking
+ */
+fun Route.gitHubIssueRoutes(config: GitHubIssueRoutesConfig) {
+
+    post("/api/issues") {
+        val clientIp = call.getClientIp()
+        call.checkRateLimit(config.rateLimiter.isAllowed(clientIp))
+
+        val multipart = call.receiveMultipart()
+        var title = ""
+        var senderName = ""
+        var senderEmail = ""
+        var description = ""
+        var consoleLogs: String? = null
+        var labels = emptyList<String>()
+        val imageData = mutableListOf<Pair<ByteArray, String>>()
+
+        multipart.forEachPart { part ->
+            when (part) {
+                is PartData.FormItem -> {
+                    when (part.name) {
+                        "title" -> title = part.value
+                        "senderName" -> senderName = part.value
+                        "senderEmail" -> senderEmail = part.value
+                        "description" -> description = part.value
+                        "consoleLogs" -> consoleLogs = part.value
+                        "labels" -> labels = part.value.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                    }
+                }
+                is PartData.FileItem -> {
+                    if (part.name == "images") {
+                        val bytes = part.provider().readBytes()
+                        val filename = part.originalFileName ?: "image"
+                        imageData.add(bytes to filename)
+                    }
+                }
+                else -> {}
+            }
+            part.dispose()
+        }
+
+        if (title.isBlank()) throw BadRequestException("Tittel er paakrevd")
+        if (senderName.isBlank()) throw BadRequestException("Avsendernavn er paakrevd")
+        if (senderEmail.isBlank()) throw BadRequestException("Avsender-epost er paakrevd")
+        if (description.isBlank()) throw BadRequestException("Beskrivelse er paakrevd")
+
+        // Opprett issue forst for aa faa issue-nummer
+        val issueResponse = config.issueService.createIssue(
+            title = title,
+            senderName = senderName,
+            senderEmail = senderEmail,
+            description = description,
+            consoleLogs = consoleLogs,
+            labels = labels
+        )
+
+        // Last opp bilder til issue-nummeret
+        val imageUrls = mutableListOf<String>()
+        if (config.imageService != null && imageData.isNotEmpty()) {
+            for ((bytes, filename) in imageData) {
+                val result = config.imageService.uploadImage(issueResponse.number, bytes, filename)
+                result.onSuccess { url -> imageUrls.add(url) }
+                result.onFailure { /* Bildeopplasting feilet, fortsetter uten */ }
+            }
+        }
+
+        call.respond(HttpStatusCode.Created, CreateIssueResponse(
+            issueNumber = issueResponse.number,
+            issueUrl = issueResponse.html_url,
+            imageUrls = imageUrls
+        ))
+    }
+
+    post("/api/issues/webhook") {
+        val clientIp = call.getClientIp()
+        call.checkRateLimit(config.rateLimiter.isAllowed(clientIp))
+
+        val payload = call.receive<ByteArray>()
+        val signature = call.request.header("X-Hub-Signature-256")
+            ?: throw ForbiddenException("Mangler webhook-signatur")
+
+        if (!verifyWebhookSignature(payload, signature, config.webhookSecret)) {
+            throw ForbiddenException("Ugyldig webhook-signatur")
+        }
+
+        val (action, issueNumber) = parseWebhookAction(String(payload))
+            ?: throw BadRequestException("Ugyldig webhook-payload")
+
+        if (action == "closed") {
+            config.imageService?.deleteIssueImages(issueNumber)
+        }
+
+        call.respond(HttpStatusCode.OK, mapOf("status" to "ok"))
+    }
+}

--- a/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
@@ -6,7 +6,7 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.io.readByteArray
+import io.ktor.utils.io.toByteArray
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.security.MessageDigest
@@ -105,7 +105,7 @@ fun Route.gitHubIssueRoutes(config: GitHubIssueRoutesConfig) {
                 }
                 is PartData.FileItem -> {
                     if (part.name == "images") {
-                        val bytes = part.provider().readByteArray()
+                        val bytes = part.provider().toByteArray()
                         val filename = part.originalFileName ?: "image"
                         imageData.add(bytes to filename)
                     }

--- a/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
@@ -105,7 +105,7 @@ fun Route.gitHubIssueRoutes(config: GitHubIssueRoutesConfig) {
                 }
                 is PartData.FileItem -> {
                     if (part.name == "images") {
-                        val bytes = part.provider().readBytes()
+                        val bytes = part.provider().readByteArray()
                         val filename = part.originalFileName ?: "image"
                         imageData.add(bytes to filename)
                     }

--- a/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
@@ -6,7 +6,7 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.ktor.utils.io.core.*
+import kotlinx.io.readByteArray
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.security.MessageDigest

--- a/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
@@ -6,6 +6,7 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.utils.io.core.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.security.MessageDigest

--- a/src/test/kotlin/no/grunnmur/GitHubIssueRoutesTest.kt
+++ b/src/test/kotlin/no/grunnmur/GitHubIssueRoutesTest.kt
@@ -1,0 +1,117 @@
+package no.grunnmur
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GitHubIssueRoutesTest {
+
+    private val secret = "test-webhook-secret"
+
+    private fun computeHmac(payload: String, secret: String): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secret.toByteArray(), "HmacSHA256"))
+        val hash = mac.doFinal(payload.toByteArray()).joinToString("") { "%02x".format(it) }
+        return "sha256=$hash"
+    }
+
+    @Nested
+    inner class VerifyWebhookSignature {
+
+        @Test
+        fun `gyldig signatur aksepteres`() {
+            val payload = """{"action":"closed","issue":{"number":42}}"""
+            val signature = computeHmac(payload, secret)
+
+            assertTrue(verifyWebhookSignature(payload.toByteArray(), signature, secret))
+        }
+
+        @Test
+        fun `ugyldig signatur avvises`() {
+            val payload = """{"action":"closed","issue":{"number":42}}"""
+            val wrongSignature = computeHmac("tampered-payload", secret)
+
+            assertFalse(verifyWebhookSignature(payload.toByteArray(), wrongSignature, secret))
+        }
+
+        @Test
+        fun `feil hemmelighet avvises`() {
+            val payload = """{"action":"closed","issue":{"number":42}}"""
+            val signature = computeHmac(payload, "wrong-secret")
+
+            assertFalse(verifyWebhookSignature(payload.toByteArray(), signature, secret))
+        }
+
+        @Test
+        fun `signatur uten sha256-prefix avvises`() {
+            val payload = """{"action":"closed","issue":{"number":42}}"""
+            val signature = computeHmac(payload, secret).removePrefix("sha256=")
+
+            assertFalse(verifyWebhookSignature(payload.toByteArray(), signature, secret))
+        }
+
+        @Test
+        fun `tom signatur avvises`() {
+            val payload = """{"action":"closed","issue":{"number":42}}"""
+
+            assertFalse(verifyWebhookSignature(payload.toByteArray(), "", secret))
+        }
+
+        @Test
+        fun `tom payload med gyldig signatur aksepteres`() {
+            val payload = ""
+            val signature = computeHmac(payload, secret)
+
+            assertTrue(verifyWebhookSignature(payload.toByteArray(), signature, secret))
+        }
+
+        @Test
+        fun `signatur med feil lengde avvises`() {
+            val payload = """{"action":"closed"}"""
+
+            assertFalse(verifyWebhookSignature(payload.toByteArray(), "sha256=abc", secret))
+        }
+    }
+
+    @Nested
+    inner class ParseWebhookAction {
+
+        @Test
+        fun `parser closed-action med issue-nummer`() {
+            val payload = """{"action":"closed","issue":{"number":42}}"""
+            val result = parseWebhookAction(payload)
+
+            assertTrue(result != null)
+            assertTrue(result!!.first == "closed")
+            assertTrue(result.second == 42)
+        }
+
+        @Test
+        fun `parser opened-action`() {
+            val payload = """{"action":"opened","issue":{"number":7}}"""
+            val result = parseWebhookAction(payload)
+
+            assertTrue(result != null)
+            assertTrue(result!!.first == "opened")
+            assertTrue(result.second == 7)
+        }
+
+        @Test
+        fun `returnerer null for ugyldig JSON`() {
+            val result = parseWebhookAction("not json")
+
+            assertTrue(result == null)
+        }
+
+        @Test
+        fun `returnerer null for payload uten issue`() {
+            val payload = """{"action":"closed"}"""
+            val result = parseWebhookAction(payload)
+
+            assertTrue(result == null)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #17

## Endringer
- `GitHubIssueRoutes.kt`: API-ruter for issue-opprettelse (multipart) og GitHub webhook
- `GitHubIssueRoutesTest.kt`: Tester for webhook-signaturverifisering og payload-parsing

## Detaljer
- `POST /api/issues` — Oppretter issue med valgfrie bilder (multipart)
- `POST /api/issues/webhook` — GitHub webhook med HMAC-SHA256-verifisering
- Rate limiting via RateLimiter på begge endepunkter
- Webhook trigger `ImageUploadService.deleteIssueImages()` ved issue-lukking
- Feilhåndtering med grunnmur-exceptions (BadRequest, Forbidden, RateLimit)