### PR TITLE
Fix #28: GitHub App token-autentisering i GitHubIssueService

### DIFF
--- a/src/main/kotlin/no/grunnmur/GitHubAppAuth.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubAppAuth.kt
@@ -1,0 +1,150 @@
+package no.grunnmur
+
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.security.KeyFactory
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
+
+/**
+ * GitHub App-autentisering med JWT (RS256) og installation token-caching.
+ *
+ * Installation tokens varer 1 time. Denne klassen cacher tokenet og
+ * fornyer det automatisk 5 minutter foer utloep.
+ */
+class GitHubAppAuth(
+    private val appId: String,
+    private val privateKeyPem: String,
+    private val installationId: String
+) {
+    @Serializable
+    private data class InstallationToken(
+        val token: String,
+        val expires_at: String
+    )
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val client by lazy { HttpClient(CIO) }
+
+    @Volatile
+    private var cachedToken: String? = null
+    @Volatile
+    private var tokenExpiresAt: Long = 0
+
+    /**
+     * Henter et gyldig installation token. Cacher og fornyer automatisk.
+     */
+    suspend fun getToken(): String {
+        val now = System.currentTimeMillis()
+        val cached = cachedToken
+        if (cached != null && now < tokenExpiresAt - 300_000) {
+            return cached
+        }
+        return refreshToken()
+    }
+
+    private suspend fun refreshToken(): String {
+        val jwt = createJwt()
+
+        val response = client.post("https://api.github.com/app/installations/$installationId/access_tokens") {
+            header("Authorization", "Bearer $jwt")
+            header("Accept", "application/vnd.github+json")
+        }
+
+        if (!response.status.isSuccess()) {
+            val errorBody = response.bodyAsText()
+            throw RuntimeException("Kunne ikke hente installation token: ${response.status} — $errorBody")
+        }
+
+        val tokenResponse = json.decodeFromString<InstallationToken>(response.bodyAsText())
+        cachedToken = tokenResponse.token
+        // Parse ISO-8601 til millis — forenklet, bruker 55 min fra naa som fallback
+        tokenExpiresAt = System.currentTimeMillis() + 55 * 60 * 1000
+        return tokenResponse.token
+    }
+
+    /**
+     * Oppretter en JWT signert med RS256 for GitHub App-autentisering.
+     * JWT-en er gyldig i 10 minutter (GitHub-krav: maks 10 min).
+     */
+    internal fun createJwt(): String {
+        val now = System.currentTimeMillis() / 1000
+        val header = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString("""{"alg":"RS256","typ":"JWT"}""".toByteArray())
+        val payload = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString("""{"iat":${now - 60},"exp":${now + 600},"iss":"$appId"}""".toByteArray())
+
+        val signingInput = "$header.$payload"
+        val privateKey = parsePrivateKey(privateKeyPem)
+        val signature = java.security.Signature.getInstance("SHA256withRSA").apply {
+            initSign(privateKey)
+            update(signingInput.toByteArray())
+        }.sign()
+
+        val encodedSignature = Base64.getUrlEncoder().withoutPadding().encodeToString(signature)
+        return "$header.$payload.$encodedSignature"
+    }
+
+    private fun parsePrivateKey(pem: String): java.security.PrivateKey {
+        val stripped = pem
+            .replace("-----BEGIN RSA PRIVATE KEY-----", "")
+            .replace("-----END RSA PRIVATE KEY-----", "")
+            .replace("-----BEGIN PRIVATE KEY-----", "")
+            .replace("-----END PRIVATE KEY-----", "")
+            .replace("\\s".toRegex(), "")
+
+        val keyBytes = Base64.getDecoder().decode(stripped)
+
+        // Proev PKCS8 foerst, deretter PKCS1 (RSA PRIVATE KEY)
+        return try {
+            KeyFactory.getInstance("RSA").generatePrivate(PKCS8EncodedKeySpec(keyBytes))
+        } catch (_: Exception) {
+            // PKCS1 format — wrap i PKCS8
+            val pkcs8Bytes = wrapPkcs1InPkcs8(keyBytes)
+            KeyFactory.getInstance("RSA").generatePrivate(PKCS8EncodedKeySpec(pkcs8Bytes))
+        }
+    }
+
+    /**
+     * Wrapper en PKCS1 RSA-noekkel i PKCS8-format.
+     * GitHub App private keys er typisk i PKCS1 (BEGIN RSA PRIVATE KEY).
+     */
+    private fun wrapPkcs1InPkcs8(pkcs1Bytes: ByteArray): ByteArray {
+        // PKCS8 header for RSA
+        val pkcs8Header = byteArrayOf(
+            0x30.toByte(), 0x82.toByte(), 0x00.toByte(), 0x00.toByte(), // SEQUENCE (placeholder length)
+            0x02.toByte(), 0x01.toByte(), 0x00.toByte(),                // INTEGER 0
+            0x30.toByte(), 0x0D.toByte(),                                // SEQUENCE
+            0x06.toByte(), 0x09.toByte(),                                // OID
+            0x2A.toByte(), 0x86.toByte(), 0x48.toByte(), 0x86.toByte(),
+            0xF7.toByte(), 0x0D.toByte(), 0x01.toByte(), 0x01.toByte(),
+            0x01.toByte(),                                               // rsaEncryption
+            0x05.toByte(), 0x00.toByte(),                                // NULL
+            0x04.toByte(), 0x82.toByte(), 0x00.toByte(), 0x00.toByte()  // OCTET STRING (placeholder length)
+        )
+
+        val totalLen = pkcs8Header.size - 4 + pkcs1Bytes.size
+        val octetLen = pkcs1Bytes.size
+
+        val result = ByteArray(4 + totalLen)
+        System.arraycopy(pkcs8Header, 0, result, 0, pkcs8Header.size)
+        System.arraycopy(pkcs1Bytes, 0, result, pkcs8Header.size, pkcs1Bytes.size)
+
+        // Fix SEQUENCE length
+        result[2] = ((totalLen shr 8) and 0xFF).toByte()
+        result[3] = (totalLen and 0xFF).toByte()
+
+        // Fix OCTET STRING length
+        val octetLenOffset = pkcs8Header.size - 2
+        result[octetLenOffset] = ((octetLen shr 8) and 0xFF).toByte()
+        result[octetLenOffset + 1] = (octetLen and 0xFF).toByte()
+
+        return result
+    }
+}

--- a/src/main/kotlin/no/grunnmur/GitHubIssueService.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueService.kt
@@ -13,15 +13,26 @@ import kotlinx.serialization.json.Json
 /**
  * Service for aa opprette GitHub Issues via API.
  * All input saniteres via [InputSanitizer].
+ *
+ * Stoetter to autentiseringsmetoder:
+ * - **PAT**: Personlig access token (Config med token)
+ * - **GitHub App**: Installation token via JWT (Config med appAuth)
  */
 class GitHubIssueService(private val config: Config) {
 
     data class Config(
-        val token: String,
+        val token: String? = null,
+        val appAuth: GitHubAppAuth? = null,
         val repo: String,
         val uploadDir: String? = null,
         val publicBaseUrl: String? = null
-    )
+    ) {
+        init {
+            require(token != null || appAuth != null) {
+                "Enten token eller appAuth maa vaere satt"
+            }
+        }
+    }
 
     @Serializable
     data class CreateIssueRequest(
@@ -41,6 +52,10 @@ class GitHubIssueService(private val config: Config) {
     }
 
     private val json = Json { ignoreUnknownKeys = true }
+
+    private suspend fun getAuthToken(): String {
+        return config.appAuth?.getToken() ?: config.token!!
+    }
 
     private val client by lazy {
         HttpClient(CIO) {
@@ -115,8 +130,9 @@ class GitHubIssueService(private val config: Config) {
             labels = labels
         )
 
+        val authToken = getAuthToken()
         val response = client.post("https://api.github.com/repos/${config.repo}/issues") {
-            header("Authorization", "Bearer ${config.token}")
+            header("Authorization", "Bearer $authToken")
             header("Accept", "application/vnd.github+json")
             header("X-GitHub-Api-Version", GITHUB_API_VERSION)
             contentType(ContentType.Application.Json)
@@ -136,8 +152,9 @@ class GitHubIssueService(private val config: Config) {
      * Brukes for aa legge til vedleggsseksjon etter bildeopplasting.
      */
     suspend fun updateIssueBody(issueNumber: Int, body: String) {
+        val authToken = getAuthToken()
         val response = client.patch("https://api.github.com/repos/${config.repo}/issues/$issueNumber") {
-            header("Authorization", "Bearer ${config.token}")
+            header("Authorization", "Bearer $authToken")
             header("Accept", "application/vnd.github+json")
             header("X-GitHub-Api-Version", GITHUB_API_VERSION)
             contentType(ContentType.Application.Json)

--- a/src/test/kotlin/no/grunnmur/GitHubAppAuthTest.kt
+++ b/src/test/kotlin/no/grunnmur/GitHubAppAuthTest.kt
@@ -1,0 +1,116 @@
+package no.grunnmur
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.Base64
+import kotlin.test.assertEquals
+import kotlin.test.assertContains
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
+
+class GitHubAppAuthTest {
+
+    // Test RSA key pair (2048 bit) — kun for testing, ikke en reell noekkel
+    private val testPrivateKey = """
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEowIBAAKCAQEA2OD0AHsbfr5AaYpFJSzfjVSzDxCLen9PazjIZbHKIH7PVbRs
+        AeEN4Ym1Zjz7Tlr+SyN87K201/JpsxqkKkFL+k+iG+JuwCx/x6mHl8kk/0v9YwxF
+        XOqp1ZaDgQor0mHmjrBhi9T+ZYIn+041uIVpir1UVAWLwU1XHFhAt4+fcpeYnbHG
+        B6TtXn6mo7UbnQL2OlLaB+qbc6vUyKvRuwNq8Z1likIRdf9PrffgoV0gKbdz6mRc
+        81AO6uuicE3yG/ezljLhDUrbpxjtnWQbny8cuxUDmlXQ5zU08jGwiQgMBOU5InLr
+        Qr55bthVLQ57HuoE7OiRRZ9s8NwjSM0qbB8NWwIDAQABAoIBADIDRiFqQj/rDZ2I
+        9kMJYxALbTNXJGL+Qsk+EfBpnGv78kIYViPkyzescvl9rJI4J5YaO++0axS1YSyd
+        Qyg/YI77mC2H/PQyDtFzRcJ57x80Xd1ecgxoTPvlNrQmLU7ZprpW8Fe3qWatKh0o
+        vvirQ1hsKqspkD3mYOU3cM0jwKhC4j3Xzh027RzwMCk7BEyRyGiF0R/6xIBWWjhA
+        TRPQiTzpdY4TtQy8PG7vapwazWYv/2irrbOb/1bXWkjeKn/K9bW1sWdImNG63huu
+        ysxBsjWRG4y315PtfjGjBc4sNzCFxMQvANKm9VymG9LAQxgw0JI/a50D96l8pRFC
+        qY7ttskCgYEA/pJJjQBJhuS1CGLb2xIjzNhAulClcZwu4+a8FfoKqwCe8avFvSv3
+        dvAVT3sa2XimotWXMyw+yC9d/o4+LljBO4hs++P+7SWf52VobL6uOi9bnrd0xd+q
+        aGonPSRMfGJVMd0cKDOxJxZQP5NxM04PcOt8cett+Q09AnZ0c5rvW6cCgYEA2hiE
+        ZKV/2Pxu9WoknzjM89m5eIfkuKLguDG6QFEhLrLD1ec9HExQBWg6DEme4+/nIvQO
+        hlPnZ2B+fpiw3am+3uV8MP91BioBN5HdDJVAdTMgpxHyMoSvzwlD5oq6A3OouHz0
+        KNn3/sIa0cdH17BDvWdPmXVnhxLKq0zSDTrupy0CgYEAvedw+L9jGj7YkXX13nms
+        vS4BMzvf/11sWVSRsK9DcAdZip0COLlotJAqxYznHZ30aPp+/YyfFQTI0JFZ74cE
+        Nx3xdwLA9DWiEKNEgALKw9r6NO9ULBxK6fNubBz89bkBJt50F8Vf/PGXUaXyxzwP
+        JsR0pCLleemXPpQREQBeWHcCgYB34ow8KwFZDIIN41fYMkfvL1qVl9WxbM8sUSF5
+        o18jJV8jIOZlvMkr/7wQ7xMpZsFeZFvrmQmVuOQvwM1QO7PRIMKgyHvSdJqQqlyh
+        QxXYls83J1VEUc22d/hcLRvNM/Gl4AHyxsZcwuQtNmcWeCz0W2rVB0VuaXUArsy0
+        OxXezQKBgHvRBgsv5mKiUdTlPaeZ5k70bGRTzDin6hMhMRX6hBEaoneRBr9kJ474
+        E/Vpa5KdpKcuGN0gH9xr4XUycBQee0P05zjI/8vzqQa4lt57ZbSFWaJpyzyy38Q0
+        1Atrs4zP2rNiYTQRgbOy3V2gwcnxkJYueETExVertuAAR2c15JfC
+        -----END RSA PRIVATE KEY-----
+    """.trimIndent()
+
+    @Nested
+    inner class JwtGenerering {
+
+        @Test
+        fun `JWT har tre deler separert med punktum`() {
+            val auth = GitHubAppAuth("123456", testPrivateKey, "789")
+            val jwt = auth.createJwt()
+            val parts = jwt.split(".")
+            assertEquals(3, parts.size, "JWT skal ha header.payload.signature")
+        }
+
+        @Test
+        fun `JWT header inneholder RS256 algoritme`() {
+            val auth = GitHubAppAuth("123456", testPrivateKey, "789")
+            val jwt = auth.createJwt()
+            val header = String(Base64.getUrlDecoder().decode(jwt.split(".")[0]))
+            assertContains(header, "RS256")
+            assertContains(header, "JWT")
+        }
+
+        @Test
+        fun `JWT payload inneholder app ID som issuer`() {
+            val auth = GitHubAppAuth("123456", testPrivateKey, "789")
+            val jwt = auth.createJwt()
+            val payload = String(Base64.getUrlDecoder().decode(jwt.split(".")[1]))
+            assertContains(payload, "\"iss\":\"123456\"")
+        }
+
+        @Test
+        fun `JWT payload inneholder iat og exp`() {
+            val auth = GitHubAppAuth("123456", testPrivateKey, "789")
+            val jwt = auth.createJwt()
+            val payload = String(Base64.getUrlDecoder().decode(jwt.split(".")[1]))
+            assertContains(payload, "\"iat\":")
+            assertContains(payload, "\"exp\":")
+        }
+
+        @Test
+        fun `JWT exp er ca 10 minutter etter iat`() {
+            val auth = GitHubAppAuth("123456", testPrivateKey, "789")
+            val jwt = auth.createJwt()
+            val payload = String(Base64.getUrlDecoder().decode(jwt.split(".")[1]))
+            val iat = Regex("\"iat\":(\\d+)").find(payload)!!.groupValues[1].toLong()
+            val exp = Regex("\"exp\":(\\d+)").find(payload)!!.groupValues[1].toLong()
+            // iat er now-60, exp er now+600, saa diff er 660
+            assertTrue(exp - iat in 600..720, "exp - iat skal vaere ca 660 sekunder, var ${exp - iat}")
+        }
+    }
+
+    @Nested
+    inner class ConfigValidering {
+
+        @Test
+        fun `Config krever enten token eller appAuth`() {
+            assertFailsWith<IllegalArgumentException> {
+                GitHubIssueService.Config(repo = "test/repo")
+            }
+        }
+
+        @Test
+        fun `Config med token er gyldig`() {
+            val config = GitHubIssueService.Config(token = "test", repo = "test/repo")
+            assertEquals("test", config.token)
+        }
+
+        @Test
+        fun `Config med appAuth er gyldig`() {
+            val auth = GitHubAppAuth("123", testPrivateKey, "456")
+            val config = GitHubIssueService.Config(appAuth = auth, repo = "test/repo")
+            assertEquals(auth, config.appAuth)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #28

## Endringer
- Ny `GitHubAppAuth`-klasse: JWT RS256-signering + installation token-caching med automatisk refresh
- `GitHubIssueService.Config`: støtter både PAT (token) og GitHub App (appAuth) modus
- 8 nye tester for JWT-generering og Config-validering

## Test plan
- [x] JWT-format (3 deler, RS256 header, app ID issuer, iat/exp)
- [x] Config validering (token vs appAuth, require-sjekk)
- [x] Bakoverkompatibilitet: eksisterende PAT-basert konfig fungerer

🤖 Generated with [Claude Code](https://claude.com/claude-code)