### PR TITLE
docs: update Ktor version to 3.4.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,10 @@ Brukes av lo-finans, biologportal, 6810 og summa-summarum.
 ## Teknisk
 
 - **Kotlin**: 2.3.20
-- **Ktor**: 3.4.1 (compileOnly)
+- **Ktor**: 3.4.2 (compileOnly)
 - **Exposed**: 0.61.0 (compileOnly)
 - **kotlinx-serialization-json**: 1.10.0 (compileOnly)
-- **Ktor Client** (CIO): 3.4.1 (compileOnly) — brukes av GitHubIssueService
+- **Ktor Client** (CIO): 3.4.2 (compileOnly) — brukes av GitHubIssueService
 - **SLF4J**: 2.0.17 (compileOnly)
 - **JVM**: 21
 - **Tester**: JUnit 5.14.3

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ services:
 
 ## Versjoner
 
-- Kotlin 2.3.20, Ktor 3.4.1 (Server + Client CIO), Exposed 0.61.0, JVM 21
+- Kotlin 2.3.20, Ktor 3.4.2 (Server + Client CIO), Exposed 0.61.0, JVM 21
 - SLF4J 2.0.17 (compileOnly)
 - Ktor og Exposed er `compileOnly` — apper bruker sine egne versjoner
 - Versjoner MÅ holdes i sync med appene (binar inkompatibilitet)


### PR DESCRIPTION
Automatisk dokumentasjonsoppdatering: Ktor 3.4.1 → 3.4.2 i CLAUDE.md og README.md. CI skippet pga paths-ignore for .md-filer.