### PR TITLE
Fix #36: TimeUtils.parseDateTime() for fleksibel dato/tid-parsing

### DIFF
--- a/src/main/kotlin/no/grunnmur/TimeUtils.kt
+++ b/src/main/kotlin/no/grunnmur/TimeUtils.kt
@@ -1,8 +1,10 @@
 package no.grunnmur
 
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 
 /**
  * Verktoey for tidssone-haandtering.
@@ -34,4 +36,20 @@ object TimeUtils {
      */
     fun formatDateTimeIso(dt: LocalDateTime): String =
         dt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+
+    /**
+     * Parser en dato- eller dato/tid-streng til LocalDateTime.
+     * Stoetter ISO datetime (2026-03-15T14:30:00) og kun dato (2026-03-15 -> start av dagen).
+     *
+     * @throws IllegalArgumentException ved ugyldig datoformat
+     */
+    fun parseDateTime(value: String): LocalDateTime = try {
+        if (value.contains('T')) {
+            LocalDateTime.parse(value, isoDateTime)
+        } else {
+            LocalDate.parse(value, isoDate).atStartOfDay()
+        }
+    } catch (e: DateTimeParseException) {
+        throw IllegalArgumentException("Ugyldig datoformat: $value", e)
+    }
 }

--- a/src/test/kotlin/no/grunnmur/TimeUtilsTest.kt
+++ b/src/test/kotlin/no/grunnmur/TimeUtilsTest.kt
@@ -1,6 +1,7 @@
 package no.grunnmur
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
 import java.time.ZoneId
 import kotlin.test.assertEquals
@@ -36,5 +37,38 @@ class TimeUtilsTest {
     @Test
     fun `OSLO_ZONE er Europe Oslo`() {
         assertEquals(ZoneId.of("Europe/Oslo"), TimeUtils.OSLO_ZONE)
+    }
+
+    @Test
+    fun `parseDateTime parser ISO datetime med T-separator`() {
+        val result = TimeUtils.parseDateTime("2026-03-15T14:30:00")
+        assertEquals(LocalDateTime.of(2026, 3, 15, 14, 30, 0), result)
+    }
+
+    @Test
+    fun `parseDateTime parser ISO datetime med sekunder og millisekunder`() {
+        val result = TimeUtils.parseDateTime("2026-03-15T14:30:45.123")
+        assertEquals(LocalDateTime.of(2026, 3, 15, 14, 30, 45, 123_000_000), result)
+    }
+
+    @Test
+    fun `parseDateTime parser kun dato og gir start av dagen`() {
+        val result = TimeUtils.parseDateTime("2026-03-15")
+        assertEquals(LocalDateTime.of(2026, 3, 15, 0, 0, 0), result)
+    }
+
+    @Test
+    fun `parseDateTime kaster IllegalArgumentException ved ugyldig format`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            TimeUtils.parseDateTime("ikke-en-dato")
+        }
+        assertTrue(ex.message!!.contains("Ugyldig datoformat"))
+    }
+
+    @Test
+    fun `parseDateTime kaster IllegalArgumentException ved tom streng`() {
+        assertThrows<IllegalArgumentException> {
+            TimeUtils.parseDateTime("")
+        }
     }
 }


### PR DESCRIPTION
Fixes #36