### PR TITLE
feat: add OtpUtils for shared OTP handling

### DIFF
--- a/src/main/kotlin/no/grunnmur/OtpUtils.kt
+++ b/src/main/kotlin/no/grunnmur/OtpUtils.kt
@@ -1,0 +1,91 @@
+package no.grunnmur
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.time.LocalDateTime
+
+/**
+ * Verktoy for OTP-haandtering (One-Time Password).
+ * Samler felles OTP-logikk som brukes paa tvers av alle apper.
+ *
+ * Genererer 6-sifrede koder med SecureRandom, hasher med SHA-256,
+ * og verifiserer med stoette for utlop, forsoksgrense og dev-modus.
+ *
+ * Lagring og utsending av OTP haandteres av den enkelte app.
+ */
+object OtpUtils {
+    private const val CODE_LENGTH = 6
+    private const val CODE_MIN = 100000
+    private const val CODE_RANGE = 900000
+    private const val DEFAULT_MAX_ATTEMPTS = 3
+    internal const val DEV_CODE = "123456"
+
+    private val secureRandom = SecureRandom()
+
+    /**
+     * Genererer en tilfeldig 6-sifret OTP-kode (100000-999999).
+     */
+    fun generateCode(): String {
+        return (CODE_MIN + secureRandom.nextInt(CODE_RANGE)).toString()
+    }
+
+    /**
+     * Hasher en OTP-kode med SHA-256.
+     * Returnerer 64 hex-tegn (lowercase).
+     *
+     * OTP-koder skal alltid lagres som hash, aldri i klartekst.
+     */
+    fun hashCode(code: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256").digest(code.toByteArray(Charsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Verifiserer en OTP-kode mot lagret hash.
+     *
+     * Sjekker i rekkefølge: forsoksgrense, utlop, dev-modus, kode-match.
+     *
+     * @param code Koden brukeren har oppgitt
+     * @param storedHash SHA-256-hash av den opprinnelige koden
+     * @param expiresAt Tidspunkt koden utloper
+     * @param attempts Antall tidligere forsok
+     * @param maxAttempts Maks tillatte forsok (standard 3)
+     * @param devMode Om dev-modus er aktivert (kode "123456" fungerer alltid)
+     */
+    fun verify(
+        code: String,
+        storedHash: String,
+        expiresAt: LocalDateTime,
+        attempts: Int,
+        maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+        devMode: Boolean = false
+    ): OtpVerificationResult {
+        if (attempts >= maxAttempts) {
+            return OtpVerificationResult.TooManyAttempts
+        }
+
+        if (TimeUtils.nowOslo().isAfter(expiresAt)) {
+            return OtpVerificationResult.Expired
+        }
+
+        if (devMode && code == DEV_CODE) {
+            return OtpVerificationResult.Success
+        }
+
+        return if (hashCode(code) == storedHash) {
+            OtpVerificationResult.Success
+        } else {
+            OtpVerificationResult.InvalidCode
+        }
+    }
+}
+
+/**
+ * Resultat av OTP-verifisering.
+ */
+sealed class OtpVerificationResult {
+    data object Success : OtpVerificationResult()
+    data object InvalidCode : OtpVerificationResult()
+    data object Expired : OtpVerificationResult()
+    data object TooManyAttempts : OtpVerificationResult()
+}

--- a/src/test/kotlin/no/grunnmur/OtpUtilsTest.kt
+++ b/src/test/kotlin/no/grunnmur/OtpUtilsTest.kt
@@ -1,0 +1,159 @@
+package no.grunnmur
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class OtpUtilsTest {
+
+    @Nested
+    inner class GenerateCode {
+        @Test
+        fun `generert kode er 6 siffer`() {
+            val code = OtpUtils.generateCode()
+            assertEquals(6, code.length)
+            assertTrue(code.all { it.isDigit() })
+        }
+
+        @Test
+        fun `generert kode er minst 100000`() {
+            repeat(100) {
+                val code = OtpUtils.generateCode()
+                assertTrue(code.toInt() >= 100000, "Kode $code er under 100000")
+            }
+        }
+
+        @Test
+        fun `genererte koder er unike`() {
+            val codes = (1..50).map { OtpUtils.generateCode() }.toSet()
+            assertTrue(codes.size > 1, "50 genererte koder bor ikke vaere identiske")
+        }
+    }
+
+    @Nested
+    inner class HashCode {
+        @Test
+        fun `hashing gir konsistent resultat`() {
+            val code = "123456"
+            val hash1 = OtpUtils.hashCode(code)
+            val hash2 = OtpUtils.hashCode(code)
+            assertEquals(hash1, hash2)
+        }
+
+        @Test
+        fun `hash er 64 hex-tegn (SHA-256)`() {
+            val hash = OtpUtils.hashCode("123456")
+            assertEquals(64, hash.length)
+            assertTrue(hash.all { it in '0'..'9' || it in 'a'..'f' })
+        }
+
+        @Test
+        fun `forskjellige koder gir forskjellige hasher`() {
+            val hash1 = OtpUtils.hashCode("123456")
+            val hash2 = OtpUtils.hashCode("654321")
+            assertNotEquals(hash1, hash2)
+        }
+
+        @Test
+        fun `hash er ikke lik original kode`() {
+            val code = "123456"
+            val hash = OtpUtils.hashCode(code)
+            assertNotEquals(code, hash)
+        }
+    }
+
+    @Nested
+    inner class Verify {
+        @Test
+        fun `gyldig kode returnerer Success`() {
+            val code = "123456"
+            val storedHash = OtpUtils.hashCode(code)
+            val expiry = TimeUtils.nowOslo().plusMinutes(5)
+
+            val result = OtpUtils.verify(code, storedHash, expiry, attempts = 0)
+            assertTrue(result is OtpVerificationResult.Success)
+        }
+
+        @Test
+        fun `feil kode returnerer InvalidCode`() {
+            val storedHash = OtpUtils.hashCode("123456")
+            val expiry = TimeUtils.nowOslo().plusMinutes(5)
+
+            val result = OtpUtils.verify("999999", storedHash, expiry, attempts = 0)
+            assertTrue(result is OtpVerificationResult.InvalidCode)
+        }
+
+        @Test
+        fun `utlopt kode returnerer Expired`() {
+            val code = "123456"
+            val storedHash = OtpUtils.hashCode(code)
+            val expiry = TimeUtils.nowOslo().minusMinutes(1)
+
+            val result = OtpUtils.verify(code, storedHash, expiry, attempts = 0)
+            assertTrue(result is OtpVerificationResult.Expired)
+        }
+
+        @Test
+        fun `for mange forsok returnerer TooManyAttempts`() {
+            val code = "123456"
+            val storedHash = OtpUtils.hashCode(code)
+            val expiry = TimeUtils.nowOslo().plusMinutes(5)
+
+            val result = OtpUtils.verify(code, storedHash, expiry, attempts = 3)
+            assertTrue(result is OtpVerificationResult.TooManyAttempts)
+        }
+
+        @Test
+        fun `maks forsok er konfigurerbar`() {
+            val code = "123456"
+            val storedHash = OtpUtils.hashCode(code)
+            val expiry = TimeUtils.nowOslo().plusMinutes(5)
+
+            val result = OtpUtils.verify(code, storedHash, expiry, attempts = 5, maxAttempts = 5)
+            assertTrue(result is OtpVerificationResult.TooManyAttempts)
+
+            val result2 = OtpUtils.verify(code, storedHash, expiry, attempts = 4, maxAttempts = 5)
+            assertTrue(result2 is OtpVerificationResult.Success)
+        }
+    }
+
+    @Nested
+    inner class DevModus {
+        @Test
+        fun `dev-kode 123456 fungerer i dev-modus`() {
+            val storedHash = OtpUtils.hashCode("999888")
+            val expiry = TimeUtils.nowOslo().plusMinutes(5)
+
+            val result = OtpUtils.verify("123456", storedHash, expiry, attempts = 0, devMode = true)
+            assertTrue(result is OtpVerificationResult.Success)
+        }
+
+        @Test
+        fun `dev-kode fungerer ikke uten dev-modus`() {
+            val storedHash = OtpUtils.hashCode("999888")
+            val expiry = TimeUtils.nowOslo().plusMinutes(5)
+
+            val result = OtpUtils.verify("123456", storedHash, expiry, attempts = 0, devMode = false)
+            assertTrue(result is OtpVerificationResult.InvalidCode)
+        }
+
+        @Test
+        fun `dev-kode sjekker fortsatt utlop`() {
+            val storedHash = OtpUtils.hashCode("999888")
+            val expiry = TimeUtils.nowOslo().minusMinutes(1)
+
+            val result = OtpUtils.verify("123456", storedHash, expiry, attempts = 0, devMode = true)
+            assertTrue(result is OtpVerificationResult.Expired)
+        }
+
+        @Test
+        fun `dev-kode sjekker fortsatt forsoksgrense`() {
+            val storedHash = OtpUtils.hashCode("999888")
+            val expiry = TimeUtils.nowOslo().plusMinutes(5)
+
+            val result = OtpUtils.verify("123456", storedHash, expiry, attempts = 3, devMode = true)
+            assertTrue(result is OtpVerificationResult.TooManyAttempts)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #38

## Endringer
- `OtpUtils.generateCode()`: 6-sifret SecureRandom-kode (100000-999999)
- `OtpUtils.hashCode()`: SHA-256-hashing for sikker lagring
- `OtpUtils.verify()`: Verifisering med utløp, forsøksgrense og dev-modus
- `OtpVerificationResult` sealed class (Success, InvalidCode, Expired, TooManyAttempts)

## Tester
- 14 tester: generering, hashing, verifisering og dev-modus