### PR TITLE
feat: add SmtpClient for shared SMTP handling (#40)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
     // Serialization
     compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
 
+    // Jakarta Mail (compileOnly — apper har sin egen versjon)
+    compileOnly("jakarta.mail:jakarta.mail-api:2.1.3")
+
     // Logging
     compileOnly("org.slf4j:slf4j-api:2.0.17")
 
@@ -52,6 +55,11 @@ dependencies {
     testImplementation("io.ktor:ktor-server-auth:$ktorVersion")
     testImplementation("io.ktor:ktor-server-auth-jwt:$ktorVersion")
     testImplementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
+
+    // Jakarta Mail (test — trenger implementasjon for å kjøre tester)
+    testImplementation("jakarta.mail:jakarta.mail-api:2.1.3")
+    testImplementation("org.eclipse.angus:angus-mail:2.0.3")
+    testImplementation("org.slf4j:slf4j-simple:2.0.17")
 }
 
 java {

--- a/src/main/kotlin/no/grunnmur/SmtpClient.kt
+++ b/src/main/kotlin/no/grunnmur/SmtpClient.kt
@@ -1,0 +1,306 @@
+package no.grunnmur
+
+import jakarta.mail.*
+import jakarta.mail.internet.InternetAddress
+import jakarta.mail.internet.MimeBodyPart
+import jakarta.mail.internet.MimeMessage
+import jakarta.mail.internet.MimeMultipart
+import jakarta.mail.util.ByteArrayDataSource
+import org.slf4j.LoggerFactory
+import java.util.*
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Konfigurasjon for SMTP-tilkobling.
+ *
+ * @param host SMTP-server hostname
+ * @param port SMTP-port (default 587 for STARTTLS)
+ * @param user Brukernavn for autentisering
+ * @param password Passord for autentisering
+ * @param from Avsender-e-postadresse
+ * @param fromName Avsendernavn (vises i e-postklient)
+ * @param requireAuth Om SMTP-autentisering kreves
+ * @param devMode I dev-modus logges e-post i stedet for aa sendes
+ * @param timeoutMs Timeout for SMTP-tilkobling og sending (default 10s)
+ * @param minIntervalMs Minimum intervall mellom sendinger i ms (rate limiting, default 100ms)
+ */
+data class SmtpConfig(
+    val host: String,
+    val port: Int = 587,
+    val user: String,
+    val password: String,
+    val from: String,
+    val fromName: String = "",
+    val requireAuth: Boolean = true,
+    val devMode: Boolean = false,
+    val timeoutMs: Int = 10_000,
+    val minIntervalMs: Long = 100
+)
+
+/**
+ * E-postmelding som skal sendes.
+ *
+ * @param to Mottakers e-postadresse
+ * @param subject Emne
+ * @param body Ren tekst-innhold
+ * @param htmlBody Valgfri HTML-versjon (oppretter multipart/alternative)
+ * @param replyTo Valgfri Reply-To-adresse
+ * @param inReplyTo Valgfri Message-ID for traad-kobling (setter In-Reply-To og References)
+ * @param attachments Liste med vedlegg
+ */
+data class EmailMessage(
+    val to: String,
+    val subject: String,
+    val body: String,
+    val htmlBody: String? = null,
+    val replyTo: String? = null,
+    val inReplyTo: String? = null,
+    val attachments: List<EmailAttachment> = emptyList()
+)
+
+/**
+ * Vedlegg til e-post.
+ *
+ * @param filename Filnavn som vises for mottaker
+ * @param content Filinnhold som ByteArray
+ * @param contentType MIME-type (f.eks. "application/pdf", "image/png")
+ */
+data class EmailAttachment(
+    val filename: String,
+    val content: ByteArray,
+    val contentType: String
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is EmailAttachment) return false
+        return filename == other.filename &&
+                content.contentEquals(other.content) &&
+                contentType == other.contentType
+    }
+
+    override fun hashCode(): Int {
+        var result = filename.hashCode()
+        result = 31 * result + content.contentHashCode()
+        result = 31 * result + contentType.hashCode()
+        return result
+    }
+}
+
+/**
+ * Resultat fra e-postsending.
+ *
+ * @param success Om sendingen var vellykket
+ * @param messageId Message-ID fra SMTP-server (eller dev-modus-ID)
+ * @param error Feilmelding hvis sending feilet
+ */
+data class SendResult(
+    val success: Boolean,
+    val messageId: String? = null,
+    val error: String? = null
+)
+
+/**
+ * Lav-nivaa SMTP-klient for sending av e-post via Jakarta Mail.
+ *
+ * Bruk:
+ * ```
+ * val smtp = SmtpClient(SmtpConfig(
+ *     host = "smtp.example.com",
+ *     port = 587,
+ *     user = "bruker",
+ *     password = "passord",
+ *     from = "noreply@example.com",
+ *     fromName = "Min App"
+ * ))
+ *
+ * val result = smtp.send(EmailMessage(
+ *     to = "mottaker@example.com",
+ *     subject = "Hei",
+ *     body = "Innhold"
+ * ))
+ * ```
+ *
+ * @param config SMTP-konfigurasjon
+ * @param transportAction Valgfri overstyring av faktisk sending (for testing)
+ */
+class SmtpClient(
+    private val config: SmtpConfig,
+    private val transportAction: ((MimeMessage) -> Unit)? = null
+) {
+    private val logger = LoggerFactory.getLogger(SmtpClient::class.java)
+    private val sendLock = ReentrantLock()
+
+    @Volatile
+    private var lastSendTime = 0L
+
+    /**
+     * Sender en e-post.
+     *
+     * @param message E-postmelding
+     * @param forceDelivery Tving sending selv i dev-modus (for OTP, invitasjoner o.l.)
+     * @return SendResult med status og messageId
+     */
+    fun send(message: EmailMessage, forceDelivery: Boolean = false): SendResult {
+        return doSend(message, forceDelivery, customMessageId = null)
+    }
+
+    /**
+     * Sender en e-post med egendefinert Message-ID for traad-kobling.
+     * Setter ogsaa In-Reply-To og References fra [EmailMessage.inReplyTo].
+     *
+     * Kritisk for biologportal sin e-post-traad-funksjonalitet.
+     *
+     * @param message E-postmelding
+     * @param messageId Egendefinert Message-ID (f.eks. "<abc-123@example.com>")
+     * @param forceDelivery Tving sending selv i dev-modus
+     * @return SendResult med status og messageId
+     */
+    fun sendWithMessageId(
+        message: EmailMessage,
+        messageId: String,
+        forceDelivery: Boolean = false
+    ): SendResult {
+        return doSend(message, forceDelivery, customMessageId = messageId)
+    }
+
+    private fun doSend(
+        message: EmailMessage,
+        forceDelivery: Boolean,
+        customMessageId: String?
+    ): SendResult {
+        if (config.devMode && !forceDelivery) {
+            logger.info("[DEV-MODUS] E-post til ${message.to}: ${message.subject}")
+            return SendResult(
+                success = true,
+                messageId = customMessageId ?: "dev-${System.currentTimeMillis()}"
+            )
+        }
+
+        return try {
+            val session = createSession()
+            val mimeMessage = buildMimeMessage(session, message, customMessageId)
+
+            sendLock.withLock {
+                val now = System.currentTimeMillis()
+                val elapsed = now - lastSendTime
+                if (elapsed < config.minIntervalMs && lastSendTime > 0) {
+                    Thread.sleep(config.minIntervalMs - elapsed)
+                }
+
+                mimeMessage.saveChanges()
+
+                if (transportAction != null) {
+                    transportAction.invoke(mimeMessage)
+                } else {
+                    Transport.send(mimeMessage)
+                }
+
+                lastSendTime = System.currentTimeMillis()
+            }
+
+            val msgId = customMessageId ?: mimeMessage.messageID
+            logger.info("E-post sendt til ${message.to}: ${message.subject} (messageId: $msgId)")
+            SendResult(success = true, messageId = msgId)
+        } catch (e: Exception) {
+            logger.error("Feil ved sending av e-post til ${message.to}: ${e.message}", e)
+            SendResult(success = false, error = e.message)
+        }
+    }
+
+    private fun createSession(): Session {
+        val props = Properties().apply {
+            put("mail.smtp.host", config.host)
+            put("mail.smtp.port", config.port.toString())
+            put("mail.smtp.auth", config.requireAuth.toString())
+            put("mail.smtp.starttls.enable", "true")
+            put("mail.smtp.connectiontimeout", config.timeoutMs.toString())
+            put("mail.smtp.timeout", config.timeoutMs.toString())
+            put("mail.smtp.writetimeout", config.timeoutMs.toString())
+        }
+
+        return if (config.requireAuth) {
+            Session.getInstance(props, object : Authenticator() {
+                override fun getPasswordAuthentication() =
+                    PasswordAuthentication(config.user, config.password)
+            })
+        } else {
+            Session.getInstance(props)
+        }
+    }
+
+    private fun buildMimeMessage(
+        session: Session,
+        message: EmailMessage,
+        customMessageId: String?
+    ): MimeMessage {
+        val mime = if (customMessageId != null) {
+            object : MimeMessage(session) {
+                override fun updateMessageID() {
+                    setHeader("Message-ID", customMessageId)
+                }
+            }
+        } else {
+            MimeMessage(session)
+        }
+
+        mime.setFrom(InternetAddress(config.from, config.fromName, "UTF-8"))
+        mime.setRecipient(Message.RecipientType.TO, InternetAddress(message.to))
+        mime.subject = message.subject
+        mime.sentDate = Date()
+
+        message.replyTo?.let {
+            mime.replyTo = arrayOf(InternetAddress(it))
+        }
+
+        message.inReplyTo?.let {
+            mime.setHeader("In-Reply-To", it)
+            mime.setHeader("References", it)
+        }
+
+        if (message.attachments.isEmpty()) {
+            setBodyContent(mime, message)
+        } else {
+            val mixed = MimeMultipart("mixed")
+
+            val bodyPart = MimeBodyPart()
+            if (message.htmlBody != null) {
+                val alt = MimeMultipart("alternative")
+                alt.addBodyPart(MimeBodyPart().apply { setText(message.body, "UTF-8") })
+                alt.addBodyPart(MimeBodyPart().apply {
+                    setContent(message.htmlBody, "text/html; charset=UTF-8")
+                })
+                bodyPart.setContent(alt)
+            } else {
+                bodyPart.setText(message.body, "UTF-8")
+            }
+            mixed.addBodyPart(bodyPart)
+
+            for (attachment in message.attachments) {
+                val attachPart = MimeBodyPart()
+                attachPart.dataHandler = jakarta.activation.DataHandler(
+                    ByteArrayDataSource(attachment.content, attachment.contentType)
+                )
+                attachPart.fileName = attachment.filename
+                mixed.addBodyPart(attachPart)
+            }
+
+            mime.setContent(mixed)
+        }
+
+        return mime
+    }
+
+    private fun setBodyContent(mime: MimeMessage, message: EmailMessage) {
+        if (message.htmlBody != null) {
+            val multipart = MimeMultipart("alternative")
+            multipart.addBodyPart(MimeBodyPart().apply { setText(message.body, "UTF-8") })
+            multipart.addBodyPart(MimeBodyPart().apply {
+                setContent(message.htmlBody, "text/html; charset=UTF-8")
+            })
+            mime.setContent(multipart)
+        } else {
+            mime.setText(message.body, "UTF-8")
+        }
+    }
+}

--- a/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
+++ b/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
@@ -1,0 +1,339 @@
+package no.grunnmur
+
+import jakarta.mail.internet.MimeMessage
+import jakarta.mail.internet.MimeMultipart
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class SmtpClientTest {
+
+    private val testConfig = SmtpConfig(
+        host = "localhost",
+        port = 2525,
+        user = "test",
+        password = "test",
+        from = "test@example.com",
+        fromName = "Test Avsender",
+        devMode = false
+    )
+
+    private val devConfig = testConfig.copy(devMode = true)
+
+    private fun captureClient(config: SmtpConfig = testConfig, messages: MutableList<MimeMessage> = mutableListOf()): Pair<SmtpClient, MutableList<MimeMessage>> {
+        val client = SmtpClient(config) { mime -> messages.add(mime) }
+        return client to messages
+    }
+
+    @Nested
+    inner class DevModus {
+
+        @Test
+        fun `dev-modus logger i stedet for aa sende`() {
+            val (client, messages) = captureClient(devConfig)
+
+            val result = client.send(EmailMessage(
+                to = "bruker@example.com",
+                subject = "Test",
+                body = "Hei"
+            ))
+
+            assertTrue(result.success, "Skal returnere suksess i dev-modus")
+            assertNotNull(result.messageId, "Skal ha messageId i dev-modus")
+            assertTrue(result.messageId!!.startsWith("dev-"), "MessageId skal starte med 'dev-'")
+            assertTrue(messages.isEmpty(), "Skal ikke sende e-post i dev-modus")
+        }
+
+        @Test
+        fun `dev-modus med forceDelivery sender faktisk`() {
+            val (client, messages) = captureClient(devConfig)
+
+            val result = client.send(
+                EmailMessage(to = "bruker@example.com", subject = "OTP", body = "123456"),
+                forceDelivery = true
+            )
+
+            assertTrue(result.success, "Skal returnere suksess med forceDelivery")
+            assertEquals(1, messages.size, "Skal sende e-post med forceDelivery")
+        }
+
+        @Test
+        fun `sendWithMessageId i dev-modus returnerer oppgitt messageId`() {
+            val (client, messages) = captureClient(devConfig)
+
+            val result = client.sendWithMessageId(
+                EmailMessage(to = "bruker@example.com", subject = "Test", body = "Hei"),
+                messageId = "<custom-123@example.com>"
+            )
+
+            assertTrue(result.success)
+            assertEquals("<custom-123@example.com>", result.messageId)
+            assertTrue(messages.isEmpty())
+        }
+    }
+
+    @Nested
+    inner class Sending {
+
+        @Test
+        fun `send returnerer SendResult med messageId`() {
+            val (client, messages) = captureClient()
+
+            val result = client.send(EmailMessage(
+                to = "mottaker@example.com",
+                subject = "Hei",
+                body = "Testmelding"
+            ))
+
+            assertTrue(result.success, "Skal returnere suksess")
+            assertNotNull(result.messageId, "Skal ha messageId")
+            assertNull(result.error, "Skal ikke ha feil")
+            assertEquals(1, messages.size, "Skal sende en e-post")
+        }
+
+        @Test
+        fun `send setter riktige felter paa MimeMessage`() {
+            val (client, messages) = captureClient()
+
+            client.send(EmailMessage(
+                to = "mottaker@example.com",
+                subject = "Viktig melding",
+                body = "Innhold her"
+            ))
+
+            val mime = messages.first()
+            assertEquals("Viktig melding", mime.subject)
+            assertTrue(mime.allRecipients.any { it.toString().contains("mottaker@example.com") })
+            assertTrue(mime.from.any { it.toString().contains("test@example.com") })
+        }
+
+        @Test
+        fun `send med htmlBody oppretter multipart alternative`() {
+            val (client, messages) = captureClient()
+
+            client.send(EmailMessage(
+                to = "mottaker@example.com",
+                subject = "HTML-test",
+                body = "Ren tekst",
+                htmlBody = "<h1>HTML</h1>"
+            ))
+
+            val mime = messages.first()
+            val content = mime.content
+            assertTrue(content is MimeMultipart, "Skal vaere multipart")
+            val multipart = content as MimeMultipart
+            assertEquals("alternative", multipart.contentType.split(";")[0].substringAfter("/"))
+        }
+
+        @Test
+        fun `send med replyTo setter Reply-To header`() {
+            val (client, messages) = captureClient()
+
+            client.send(EmailMessage(
+                to = "mottaker@example.com",
+                subject = "Svar",
+                body = "Test",
+                replyTo = "svar@example.com"
+            ))
+
+            val mime = messages.first()
+            assertTrue(mime.replyTo.any { it.toString().contains("svar@example.com") })
+        }
+
+        @Test
+        fun `send med feil returnerer failure SendResult`() {
+            val client = SmtpClient(testConfig) { throw RuntimeException("SMTP-feil") }
+
+            val result = client.send(EmailMessage(
+                to = "mottaker@example.com",
+                subject = "Feil",
+                body = "Test"
+            ))
+
+            assertFalse(result.success, "Skal returnere feil")
+            assertNotNull(result.error, "Skal ha feilmelding")
+            assertTrue(result.error!!.contains("SMTP-feil"))
+        }
+    }
+
+    @Nested
+    inner class SendWithMessageId {
+
+        @Test
+        fun `sendWithMessageId setter custom Message-ID`() {
+            val (client, messages) = captureClient()
+
+            client.sendWithMessageId(
+                EmailMessage(to = "mottaker@example.com", subject = "Traad", body = "Test"),
+                messageId = "<abc-123@example.com>"
+            )
+
+            val mime = messages.first()
+            assertEquals("<abc-123@example.com>", mime.getHeader("Message-ID")?.firstOrNull())
+        }
+
+        @Test
+        fun `sendWithMessageId setter In-Reply-To og References`() {
+            val (client, messages) = captureClient()
+
+            client.sendWithMessageId(
+                EmailMessage(
+                    to = "mottaker@example.com",
+                    subject = "Re: Traad",
+                    body = "Svar",
+                    inReplyTo = "<original-123@example.com>"
+                ),
+                messageId = "<reply-456@example.com>"
+            )
+
+            val mime = messages.first()
+            assertEquals("<original-123@example.com>", mime.getHeader("In-Reply-To")?.firstOrNull())
+            assertEquals("<original-123@example.com>", mime.getHeader("References")?.firstOrNull())
+        }
+
+        @Test
+        fun `sendWithMessageId returnerer oppgitt messageId i SendResult`() {
+            val (client, _) = captureClient()
+
+            val result = client.sendWithMessageId(
+                EmailMessage(to = "mottaker@example.com", subject = "Test", body = "Test"),
+                messageId = "<custom@example.com>"
+            )
+
+            assertTrue(result.success)
+            assertEquals("<custom@example.com>", result.messageId)
+        }
+    }
+
+    @Nested
+    inner class RateLimiting {
+
+        @Test
+        fun `rate limiting overolder minInterval mellom sendinger`() {
+            val config = testConfig.copy(minIntervalMs = 100)
+            val (client, _) = captureClient(config)
+
+            val start = System.currentTimeMillis()
+            client.send(EmailMessage(to = "a@test.com", subject = "1", body = "1"))
+            client.send(EmailMessage(to = "b@test.com", subject = "2", body = "2"))
+            val elapsed = System.currentTimeMillis() - start
+
+            assertTrue(elapsed >= 100, "Skal vente minst 100ms mellom sendinger, brukte ${elapsed}ms")
+        }
+
+        @Test
+        fun `rate limiting gjelder ikke i dev-modus`() {
+            val config = devConfig.copy(minIntervalMs = 500)
+            val (client, _) = captureClient(config)
+
+            val start = System.currentTimeMillis()
+            repeat(5) {
+                client.send(EmailMessage(to = "a@test.com", subject = "Test $it", body = "Test"))
+            }
+            val elapsed = System.currentTimeMillis() - start
+
+            assertTrue(elapsed < 500, "Dev-modus skal ikke rate-limite, brukte ${elapsed}ms")
+        }
+    }
+
+    @Nested
+    inner class Vedlegg {
+
+        @Test
+        fun `send med vedlegg oppretter multipart mixed`() {
+            val (client, messages) = captureClient()
+
+            client.send(EmailMessage(
+                to = "mottaker@example.com",
+                subject = "Med vedlegg",
+                body = "Se vedlegg",
+                attachments = listOf(
+                    EmailAttachment("test.txt", "Innhold".toByteArray(), "text/plain")
+                )
+            ))
+
+            val mime = messages.first()
+            val content = mime.content
+            assertTrue(content is MimeMultipart, "Skal vaere multipart")
+            val multipart = content as MimeMultipart
+            assertTrue(multipart.contentType.contains("mixed"), "Skal vaere multipart/mixed")
+            assertEquals(2, multipart.count, "Skal ha tekst + 1 vedlegg")
+        }
+
+        @Test
+        fun `send med flere vedlegg inkluderer alle`() {
+            val (client, messages) = captureClient()
+
+            client.send(EmailMessage(
+                to = "mottaker@example.com",
+                subject = "Flere vedlegg",
+                body = "Se vedlegg",
+                attachments = listOf(
+                    EmailAttachment("a.txt", "A".toByteArray(), "text/plain"),
+                    EmailAttachment("b.pdf", "B".toByteArray(), "application/pdf"),
+                    EmailAttachment("c.png", "C".toByteArray(), "image/png")
+                )
+            ))
+
+            val mime = messages.first()
+            val multipart = mime.content as MimeMultipart
+            assertEquals(4, multipart.count, "Skal ha tekst + 3 vedlegg")
+        }
+
+        @Test
+        fun `vedlegg med htmlBody har riktig struktur`() {
+            val (client, messages) = captureClient()
+
+            client.send(EmailMessage(
+                to = "mottaker@example.com",
+                subject = "HTML + vedlegg",
+                body = "Tekst",
+                htmlBody = "<p>HTML</p>",
+                attachments = listOf(
+                    EmailAttachment("test.txt", "Data".toByteArray(), "text/plain")
+                )
+            ))
+
+            val mime = messages.first()
+            val mixed = mime.content as MimeMultipart
+            assertTrue(mixed.contentType.contains("mixed"))
+            assertEquals(2, mixed.count, "Skal ha body-del + 1 vedlegg")
+        }
+    }
+
+    @Nested
+    inner class Konfigurasjon {
+
+        @Test
+        fun `SmtpConfig har fornuftige standardverdier`() {
+            val config = SmtpConfig(
+                host = "smtp.example.com",
+                port = 587,
+                user = "bruker",
+                password = "passord",
+                from = "noreply@example.com"
+            )
+
+            assertEquals("", config.fromName)
+            assertTrue(config.requireAuth)
+            assertFalse(config.devMode)
+            assertEquals(10_000, config.timeoutMs)
+            assertEquals(100L, config.minIntervalMs)
+        }
+
+        @Test
+        fun `EmailAttachment equals og hashCode fungerer med ByteArray`() {
+            val a = EmailAttachment("test.txt", "hello".toByteArray(), "text/plain")
+            val b = EmailAttachment("test.txt", "hello".toByteArray(), "text/plain")
+            val c = EmailAttachment("test.txt", "world".toByteArray(), "text/plain")
+
+            assertEquals(a, b, "Like vedlegg skal vaere like")
+            assertEquals(a.hashCode(), b.hashCode())
+            assertFalse(a == c, "Ulike vedlegg skal ikke vaere like")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SmtpClient` with Jakarta Mail for shared SMTP handling across all Ktor apps
- Includes `SmtpConfig`, `EmailMessage`, `EmailAttachment`, `SendResult` data classes
- Supports `send()`, `sendWithMessageId()` (thread linking), dev mode with `forceDelivery`, rate limiting, attachments, and timeout configuration
- 18 tests covering all functionality

Fixes #40

## Test plan
- [x] All 18 SmtpClientTest tests pass locally
- [x] Full grunnmur test suite passes
- [x] CI hurtigsjekk passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)