### PR TITLE
Fix: disable STARTTLS for local Postfix SMTP

### DIFF
--- a/src/main/kotlin/no/grunnmur/SmtpClient.kt
+++ b/src/main/kotlin/no/grunnmur/SmtpClient.kt
@@ -217,7 +217,7 @@ class SmtpClient(
             put("mail.smtp.host", config.host)
             put("mail.smtp.port", config.port.toString())
             put("mail.smtp.auth", config.requireAuth.toString())
-            put("mail.smtp.starttls.enable", "true")
+            put("mail.smtp.starttls.enable", config.requireAuth.toString())
             put("mail.smtp.connectiontimeout", config.timeoutMs.toString())
             put("mail.smtp.timeout", config.timeoutMs.toString())
             put("mail.smtp.writetimeout", config.timeoutMs.toString())

--- a/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
+++ b/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
@@ -386,6 +386,22 @@ class SmtpClientTest {
         }
 
         @Test
+        fun `send med requireAuth false fungerer uten STARTTLS`() {
+            val noAuthConfig = testConfig.copy(requireAuth = false)
+            val messages = mutableListOf<MimeMessage>()
+            val client = SmtpClient(noAuthConfig) { mime -> messages.add(mime) }
+
+            val result = client.send(EmailMessage(
+                to = "biolog@example.com",
+                subject = "OTP-kode",
+                body = "Din kode er 123456"
+            ))
+
+            assertTrue(result.success, "Skal kunne sende uten auth/STARTTLS")
+            assertEquals(1, messages.size)
+        }
+
+        @Test
         fun `EmailAttachment equals og hashCode fungerer med ByteArray`() {
             val a = EmailAttachment("test.txt", "hello".toByteArray(), "text/plain")
             val b = EmailAttachment("test.txt", "hello".toByteArray(), "text/plain")


### PR DESCRIPTION
## Summary
- Disables STARTTLS when `requireAuth=false` (local Postfix on port 25)
- Fixes "Could not convert socket to TLS" errors when sending OTP login codes
- Related to TommySkogstad/biologportal#205

## Test plan
- [x] Grunnmur tests pass (new test added for `requireAuth=false` scenario)
- [x] Biologportal backend tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)