### PR TITLE
feat: add AuthRateLimiter with per-identifier rate limiting (#72)

### DIFF
--- a/src/main/kotlin/no/grunnmur/RateLimitPresets.kt
+++ b/src/main/kotlin/no/grunnmur/RateLimitPresets.kt
@@ -151,6 +151,7 @@ class AuthRateLimiter(
     private val ipLimiter: CompositeRateLimiter,
     private val identifierLimiter: RateLimiter
 ) {
+    private val salt = java.util.UUID.randomUUID().toString()
     /**
      * Sjekker om baade IP og identifikator er tillatt.
      * Registrerer forsoeket i begge uavhengig av resultat.
@@ -192,7 +193,7 @@ class AuthRateLimiter(
 
     private fun hashIdentifier(identifier: String): String {
         val digest = MessageDigest.getInstance("SHA-256")
-        return digest.digest(identifier.toByteArray())
+        return digest.digest("$salt:$identifier".toByteArray())
             .joinToString("") { "%02x".format(it) }
     }
 }

--- a/src/main/kotlin/no/grunnmur/RateLimitPresets.kt
+++ b/src/main/kotlin/no/grunnmur/RateLimitPresets.kt
@@ -1,5 +1,7 @@
 package no.grunnmur
 
+import java.security.MessageDigest
+
 /**
  * Sammensatt rate limiter som sjekker flere vinduer (alle maa tillate).
  * Brukes for auth-ruter som trenger baade per-minutt og per-time begrensning.
@@ -125,3 +127,105 @@ fun apiRateLimiterAnonymous(
     maxRequests: Int = 20,
     windowMs: Long = 60_000
 ): RateLimiter = RateLimiter(maxAttempts = maxRequests, windowMs = windowMs)
+
+/**
+ * Rate limiter som kombinerer IP-basert og identifikator-basert limiting.
+ * Begge sjekkes alltid — den strengeste vinner (begge maa tillate).
+ * Identifikatorer (telefonnummer/e-post) hashes med SHA-256 saa de ikke lagres i klartekst.
+ *
+ * Bruk:
+ * ```
+ * val limiter = authRateLimiterWithIdentifier()
+ *
+ * post("/api/auth/send-otp") {
+ *     val ip = call.getClientIp()
+ *     val phone = call.receive<OtpRequest>().phone
+ *     call.checkRateLimit(
+ *         limiter.isAllowed(ip, phone),
+ *         retryAfterSeconds = limiter.retryAfterSeconds(ip, phone)
+ *     )
+ * }
+ * ```
+ */
+class AuthRateLimiter(
+    private val ipLimiter: CompositeRateLimiter,
+    private val identifierLimiter: RateLimiter
+) {
+    /**
+     * Sjekker om baade IP og identifikator er tillatt.
+     * Registrerer forsoeket i begge uavhengig av resultat.
+     */
+    fun isAllowed(ip: String, identifier: String): Boolean {
+        val hashedId = hashIdentifier(identifier)
+        val ipAllowed = ipLimiter.isAllowed(ip)
+        val idAllowed = identifierLimiter.isAllowed(hashedId)
+        return ipAllowed && idAllowed
+    }
+
+    /**
+     * Nullstiller tellerne for baade IP og identifikator.
+     */
+    fun reset(ip: String, identifier: String) {
+        ipLimiter.reset(ip)
+        identifierLimiter.reset(hashIdentifier(identifier))
+    }
+
+    /**
+     * Returnerer minimum gjenstaaende forsoek paa tvers av IP og identifikator.
+     */
+    fun remainingAttempts(ip: String, identifier: String): Int {
+        return minOf(
+            ipLimiter.remainingAttempts(ip),
+            identifierLimiter.remainingAttempts(hashIdentifier(identifier))
+        )
+    }
+
+    /**
+     * Returnerer maksimum retry-after-tid paa tvers av IP og identifikator.
+     * Returnerer null hvis ingen er blokkert.
+     */
+    fun retryAfterSeconds(ip: String, identifier: String): Long? {
+        val ipRetry = ipLimiter.retryAfterSeconds(ip)
+        val idRetry = identifierLimiter.retryAfterSeconds(hashIdentifier(identifier))
+        return listOfNotNull(ipRetry, idRetry).maxOrNull()
+    }
+
+    private fun hashIdentifier(identifier: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(identifier.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+    }
+}
+
+/**
+ * Ferdigkonfigurert rate limiter for auth-ruter med identifikator-basert limiting.
+ * Kombinerer IP-basert (5/min + 10/time) og identifikator-basert (5/15min).
+ *
+ * Bruk i Ktor:
+ * ```
+ * val authLimiter = authRateLimiterWithIdentifier()
+ *
+ * post("/api/auth/send-otp") {
+ *     val ip = call.getClientIp()
+ *     val phone = call.receive<OtpRequest>().phone
+ *     call.checkRateLimit(
+ *         authLimiter.isAllowed(ip, phone),
+ *         retryAfterSeconds = authLimiter.retryAfterSeconds(ip, phone)
+ *     )
+ * }
+ * ```
+ */
+fun authRateLimiterWithIdentifier(
+    perMinuteMax: Int = 5,
+    perMinuteWindowMs: Long = 60_000,
+    perHourMax: Int = 10,
+    perHourWindowMs: Long = 3_600_000,
+    perIdentifierMax: Int = 5,
+    perIdentifierWindowMs: Long = 900_000
+): AuthRateLimiter = AuthRateLimiter(
+    ipLimiter = CompositeRateLimiter(
+        RateLimiter(maxAttempts = perMinuteMax, windowMs = perMinuteWindowMs),
+        RateLimiter(maxAttempts = perHourMax, windowMs = perHourWindowMs)
+    ),
+    identifierLimiter = RateLimiter(maxAttempts = perIdentifierMax, windowMs = perIdentifierWindowMs)
+)

--- a/src/test/kotlin/no/grunnmur/RateLimitPresetsTest.kt
+++ b/src/test/kotlin/no/grunnmur/RateLimitPresetsTest.kt
@@ -282,6 +282,19 @@ class RateLimitPresetsTest {
     }
 
     @Test
+    fun `AuthRateLimiter remainingAttempts returnerer minimum av IP og identifikator`() {
+        val limiter = authRateLimiterWithIdentifier(
+            perMinuteMax = 3, perHourMax = 10,
+            perIdentifierMax = 5, perIdentifierWindowMs = 900_000
+        )
+        limiter.isAllowed("ip1", "phone1")
+        limiter.isAllowed("ip1", "phone1")
+        // IP per-minutt har 1 igjen (3-2), identifikator har 3 igjen (5-2)
+        assertEquals(1, limiter.remainingAttempts("ip1", "phone1"),
+            "Skal returnere minimum av IP (1) og identifikator (3)")
+    }
+
+    @Test
     fun `AuthRateLimiter retryAfterSeconds returnerer maksimum av IP og identifikator`() {
         val limiter = authRateLimiterWithIdentifier(
             perMinuteMax = 1, perMinuteWindowMs = 30_000,
@@ -293,7 +306,7 @@ class RateLimitPresetsTest {
 
         val retryAfter = limiter.retryAfterSeconds("ip1", "phone1")
         assertNotNull(retryAfter)
-        // Identifikator-vindu er 900s, IP time-vindu er 3600s — maks skal vaere naer 3600
+        // Per-minutt IP-vindu er 30s, identifikator-vindu er 900s — maks skal vaere naer 900
         assertTrue(retryAfter > 30, "Skal returnere maks av alle vinduer, var $retryAfter")
     }
 

--- a/src/test/kotlin/no/grunnmur/RateLimitPresetsTest.kt
+++ b/src/test/kotlin/no/grunnmur/RateLimitPresetsTest.kt
@@ -1,9 +1,11 @@
 package no.grunnmur
 
 import org.junit.jupiter.api.Test
+import java.security.MessageDigest
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class RateLimitPresetsTest {
@@ -214,6 +216,118 @@ class RateLimitPresetsTest {
             assertEquals(30L, e.retryAfterSeconds)
         }
     }
+
+    // --- AuthRateLimiter ---
+
+    @Test
+    fun `AuthRateLimiter tillater naar baade IP og identifikator er OK`() {
+        val limiter = authRateLimiterWithIdentifier(
+            perMinuteMax = 5, perHourMax = 10,
+            perIdentifierMax = 5, perIdentifierWindowMs = 900_000
+        )
+        assertTrue(limiter.isAllowed("192.168.1.1", "+4712345678"))
+    }
+
+    @Test
+    fun `AuthRateLimiter blokkerer naar IP er blokkert`() {
+        val limiter = authRateLimiterWithIdentifier(
+            perMinuteMax = 2, perHourMax = 10,
+            perIdentifierMax = 10, perIdentifierWindowMs = 900_000
+        )
+        assertTrue(limiter.isAllowed("ip1", "phone1"))
+        assertTrue(limiter.isAllowed("ip1", "phone1"))
+        assertFalse(limiter.isAllowed("ip1", "phone1"), "Skal blokkeres av IP per-minutt limiter")
+    }
+
+    @Test
+    fun `AuthRateLimiter blokkerer naar identifikator er blokkert`() {
+        val limiter = authRateLimiterWithIdentifier(
+            perMinuteMax = 10, perHourMax = 20,
+            perIdentifierMax = 2, perIdentifierWindowMs = 900_000
+        )
+        assertTrue(limiter.isAllowed("ip1", "phone1"))
+        assertTrue(limiter.isAllowed("ip2", "phone1"))
+        assertFalse(limiter.isAllowed("ip3", "phone1"), "Skal blokkeres av identifikator-limiter")
+    }
+
+    @Test
+    fun `AuthRateLimiter registrerer forsoek i begge selv naar en blokkerer`() {
+        val limiter = authRateLimiterWithIdentifier(
+            perMinuteMax = 2, perHourMax = 10,
+            perIdentifierMax = 5, perIdentifierWindowMs = 900_000
+        )
+        // Bruk opp IP per-minutt
+        assertTrue(limiter.isAllowed("ip1", "phone1"))
+        assertTrue(limiter.isAllowed("ip1", "phone1"))
+        // IP er blokkert, men identifikator skal fortsatt registreres
+        assertFalse(limiter.isAllowed("ip1", "phone1"))
+
+        // Identifikator har naa 3 forsoek — verifiser at 2 igjen
+        assertEquals(2, limiter.remainingAttempts("ip2", "phone1"),
+            "Identifikator skal ha 3 brukt via ip1, foerste kall for ip2 gir 2 igjen for identifikator")
+    }
+
+    @Test
+    fun `AuthRateLimiter reset nullstiller baade IP og identifikator`() {
+        val limiter = authRateLimiterWithIdentifier(
+            perMinuteMax = 2, perHourMax = 10,
+            perIdentifierMax = 2, perIdentifierWindowMs = 900_000
+        )
+        assertTrue(limiter.isAllowed("ip1", "phone1"))
+        assertTrue(limiter.isAllowed("ip1", "phone1"))
+        assertFalse(limiter.isAllowed("ip1", "phone1"))
+
+        limiter.reset("ip1", "phone1")
+        assertTrue(limiter.isAllowed("ip1", "phone1"), "Skal vaere tillatt etter reset")
+    }
+
+    @Test
+    fun `AuthRateLimiter retryAfterSeconds returnerer maksimum av IP og identifikator`() {
+        val limiter = authRateLimiterWithIdentifier(
+            perMinuteMax = 1, perMinuteWindowMs = 30_000,
+            perHourMax = 10, perHourWindowMs = 3_600_000,
+            perIdentifierMax = 1, perIdentifierWindowMs = 900_000
+        )
+        limiter.isAllowed("ip1", "phone1")
+        assertFalse(limiter.isAllowed("ip1", "phone1"))
+
+        val retryAfter = limiter.retryAfterSeconds("ip1", "phone1")
+        assertNotNull(retryAfter)
+        // Identifikator-vindu er 900s, IP time-vindu er 3600s — maks skal vaere naer 3600
+        assertTrue(retryAfter > 30, "Skal returnere maks av alle vinduer, var $retryAfter")
+    }
+
+    @Test
+    fun `AuthRateLimiter retryAfterSeconds returnerer null naar ikke blokkert`() {
+        val limiter = authRateLimiterWithIdentifier()
+        assertNull(limiter.retryAfterSeconds("ip1", "phone1"))
+    }
+
+    @Test
+    fun `AuthRateLimiter hasher identifikatorer`() {
+        val limiter = authRateLimiterWithIdentifier(
+            perMinuteMax = 10, perHourMax = 20,
+            perIdentifierMax = 2, perIdentifierWindowMs = 900_000
+        )
+        // Bruk opp identifikator-limiter med ulike IP-er
+        assertTrue(limiter.isAllowed("ip1", "+4712345678"))
+        assertTrue(limiter.isAllowed("ip2", "+4712345678"))
+        assertFalse(limiter.isAllowed("ip3", "+4712345678"),
+            "Identifikator skal vaere blokkert uavhengig av IP")
+
+        // Annen identifikator skal fortsatt fungere
+        assertTrue(limiter.isAllowed("ip3", "+4798765432"),
+            "Annen identifikator skal vaere upavirket")
+    }
+
+    @Test
+    fun `authRateLimiterWithIdentifier factory-funksjon bruker standardverdier`() {
+        val limiter = authRateLimiterWithIdentifier()
+        // Standardverdier: 5/min IP, 10/time IP, 5/15min identifikator
+        repeat(5) { assertTrue(limiter.isAllowed("ip1", "phone${it}"), "Forsoek ${it + 1} med unik identifikator") }
+        assertFalse(limiter.isAllowed("ip1", "phone99"), "6. forsoek fra samme IP skal blokkeres")
+    }
+
 }
 
 /**


### PR DESCRIPTION
Fixes #72

## Summary
- Add `AuthRateLimiter` class combining IP-based and identifier-based (phone/email) rate limiting
- Add `authRateLimiterWithIdentifier()` factory function with sensible defaults (5/min + 10/hr per IP, 5/15min per identifier)
- SHA-256 hash identifiers with instance-specific salt for GDPR compliance
- Backward compatible: existing `authRateLimiter()` unchanged

## Test plan
- [x] AuthRateLimiter blocks when IP is blocked
- [x] AuthRateLimiter blocks when identifier is blocked (distributed brute-force)
- [x] Both limiters register attempts even when one blocks
- [x] Reset clears both IP and identifier
- [x] retryAfterSeconds returns maximum across all windows
- [x] remainingAttempts returns minimum across IP and identifier
- [x] Hashed identifiers isolate different phone numbers
- [x] Factory function uses correct defaults
- [x] Full test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)