### PR TITLE
chore(flyway): align to 11.8.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ Config: `Config(uploadDir, baseUrl, repo = "", maxFileSize = 2MB, maxImagesPerIs
 - **Exposed**: 1.2.0 (compileOnly)
 - **kotlinx-serialization-json**: 1.11.0 (compileOnly)
 - **Jakarta Mail**: 2.1.5 (compileOnly)
-- **Flyway**: 11.20.3 (compileOnly)
+- **Flyway**: 11.8.2 (compileOnly — pinnet pga bug i 11.20.3/12.x)
 - **kotlin-onetimepassword**: 2.4.1 (compileOnly)
 - **SLF4J**: 2.0.17 (compileOnly)
 - **JVM**: 25

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,8 +39,9 @@ dependencies {
     compileOnly("jakarta.mail:jakarta.mail-api:2.1.5")
 
     // Flyway (compileOnly — apper har sin egen versjon)
-    compileOnly("org.flywaydb:flyway-core:11.20.3")
-    compileOnly("org.flywaydb:flyway-database-postgresql:11.20.3")
+    // Pinnet 11.8.2: 11.20.3 og 12.x er buggy, se MEMORY.md
+    compileOnly("org.flywaydb:flyway-core:11.8.2")
+    compileOnly("org.flywaydb:flyway-database-postgresql:11.8.2")
 
     // TOTP (compileOnly — apper har sin egen versjon)
     compileOnly("dev.turingcomplete:kotlin-onetimepassword:2.4.1")
@@ -68,9 +69,9 @@ dependencies {
     testImplementation("org.eclipse.angus:angus-mail:2.0.5")
     testImplementation("org.slf4j:slf4j-simple:2.0.17")
 
-    // Flyway (test)
-    testImplementation("org.flywaydb:flyway-core:11.20.3")
-    testImplementation("org.flywaydb:flyway-database-postgresql:11.20.3")
+    // Flyway (test) — matcher compileOnly
+    testImplementation("org.flywaydb:flyway-core:11.8.2")
+    testImplementation("org.flywaydb:flyway-database-postgresql:11.8.2")
 
     // H2 (test — in-memory database for Flyway-tester)
     testImplementation("com.h2database:h2:2.4.240")


### PR DESCRIPTION
## Sammendrag

- Flyway `compileOnly` + `testImplementation`: `11.20.3 → 11.8.2`
- Oppdatert CLAUDE.md for å reflektere pinning

## Hvorfor

Alle 4 apper pinner Flyway til 11.8.2 fordi 11.20.3 og 12.x er buggy (se MEMORY.md). grunnmur-backend hadde drevet til 11.20.3 og genererte dep-drift-concerns i status-DB.

## Test plan

- [ ] CI grønn (compileKotlin + test)
- [ ] Status-DB: 4 medium flyway-concerns forsvinner ved neste dep-drift-kjøring

Lukker konsern-cluster: `[med] tech-debt: Dep-drift (backend): flyway app=11.8.2 vs grunnmur=11.20.3` på 6810, biologportal, lo-finans, styreportal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)