### PR TITLE
ci(hotfix): add types:[labeled] to trigger on ci:run label

### DIFF
--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -2,6 +2,7 @@ name: Fullstendig testsuite
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches: [main]
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
Hotfix til [#81](..) — uten `types: [labeled]` fyrer ikke pull_request_target-workflow naar dependabot-weekly setter `ci:run` paa en aapen PR. Verifisert ved lo-finans#205.