### PR TITLE
Fix #85: make GitHubIssueService and GitHubAppAuth Closeable

### DIFF
--- a/src/main/kotlin/no/grunnmur/GitHubAppAuth.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubAppAuth.kt
@@ -7,6 +7,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import java.io.Closeable
 import java.security.KeyFactory
 import java.security.spec.PKCS8EncodedKeySpec
 import java.util.Base64
@@ -21,7 +22,7 @@ class GitHubAppAuth(
     private val appId: String,
     private val privateKeyPem: String,
     private val installationId: String
-) {
+) : Closeable {
     @Serializable
     private data class InstallationToken(
         val token: String,
@@ -30,12 +31,19 @@ class GitHubAppAuth(
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    private val client by lazy { HttpClient(CIO) }
+    private val clientLazy = lazy { HttpClient(CIO) }
+    private val client by clientLazy
 
     @Volatile
     private var cachedToken: String? = null
     @Volatile
     private var tokenExpiresAt: Long = 0
+
+    override fun close() {
+        if (clientLazy.isInitialized()) {
+            clientLazy.value.close()
+        }
+    }
 
     /**
      * Henter et gyldig installation token. Cacher og fornyer automatisk.

--- a/src/main/kotlin/no/grunnmur/GitHubIssueService.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueService.kt
@@ -9,6 +9,7 @@ import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import java.io.Closeable
 
 /**
  * Service for aa opprette GitHub Issues via API.
@@ -18,7 +19,7 @@ import kotlinx.serialization.json.Json
  * - **PAT**: Personlig access token (Config med token)
  * - **GitHub App**: Installation token via JWT (Config med appAuth)
  */
-class GitHubIssueService(private val config: Config) {
+class GitHubIssueService(private val config: Config) : Closeable {
 
     data class Config(
         val token: String? = null,
@@ -55,11 +56,18 @@ class GitHubIssueService(private val config: Config) {
             ?: throw IllegalStateException("GitHubIssueService: Verken appAuth eller token er konfigurert")
     }
 
-    private val client by lazy {
+    private val clientLazy = lazy {
         HttpClient(CIO) {
             install(ContentNegotiation) {
                 json(this@GitHubIssueService.json)
             }
+        }
+    }
+    private val client by clientLazy
+
+    override fun close() {
+        if (clientLazy.isInitialized()) {
+            clientLazy.value.close()
         }
     }
 

--- a/src/test/kotlin/no/grunnmur/GitHubAppAuthTest.kt
+++ b/src/test/kotlin/no/grunnmur/GitHubAppAuthTest.kt
@@ -2,6 +2,7 @@ package no.grunnmur
 
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.io.Closeable
 import java.util.Base64
 import kotlin.test.assertEquals
 import kotlin.test.assertContains
@@ -111,6 +112,19 @@ class GitHubAppAuthTest {
             val auth = GitHubAppAuth("123", testPrivateKey, "456")
             val config = GitHubIssueService.Config(appAuth = auth, repo = "test/repo")
             assertEquals(auth, config.appAuth)
+        }
+    }
+
+    @Nested
+    inner class Lifecycle {
+
+        @Test
+        fun `GitHubAppAuth implementerer Closeable og close frigjoer HttpClient uten aa kaste`() {
+            val auth = GitHubAppAuth("123", testPrivateKey, "456")
+            assertTrue(auth is Closeable, "GitHubAppAuth skal implementere java.io.Closeable")
+            auth.close()
+            // Skal vaere idempotent
+            auth.close()
         }
     }
 }

--- a/src/test/kotlin/no/grunnmur/GitHubIssueServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/GitHubIssueServiceTest.kt
@@ -1,6 +1,7 @@
 package no.grunnmur
 
 import org.junit.jupiter.api.Test
+import java.io.Closeable
 import kotlin.test.assertEquals
 import kotlin.test.assertContains
 import kotlin.test.assertFalse
@@ -192,5 +193,15 @@ class GitHubIssueServiceTest {
         assertContains(updatedBody, "### Vedlegg")
         assertContains(updatedBody, "![abc-123.png](https://example.com/uploads/issues/biologportal/42/abc-123.png)")
         assertContains(updatedBody, "![def-456.jpg](https://example.com/uploads/issues/biologportal/42/def-456.jpg)")
+    }
+
+    @Test
+    fun `GitHubIssueService implementerer Closeable og close frigjoer HttpClient uten aa kaste`() {
+        val service = GitHubIssueService(config)
+        assertTrue(service is Closeable, "GitHubIssueService skal implementere java.io.Closeable")
+        // Skal ikke kaste selv om HttpClient ikke er initialisert (lazy)
+        service.close()
+        // Skal vaere idempotent — gjentatt close skal ikke kaste
+        service.close()
     }
 }


### PR DESCRIPTION
## Summary
- `GitHubIssueService` og `GitHubAppAuth` implementerer naa `java.io.Closeable`
- `close()` frigjoer `HttpClient`-ressurser (sockets, trådpool) naar appen shuttes ned
- `close()` bruker `Lazy.isInitialized()` saa ubrukt klient ikke tvinges opp for aa lukkes
- Idempotent: gjentatt `close()` kaster ikke

Fixes #85

## Test plan
- [x] Rød test skrevet først (Closeable-sjekk)
- [x] `./gradlew test` groen
- [x] Nye tester verifiserer Closeable + idempotent close()