### PR TITLE
Fix #86: cache Jakarta Mail Session in SmtpClient

### DIFF
--- a/src/main/kotlin/no/grunnmur/SmtpClient.kt
+++ b/src/main/kotlin/no/grunnmur/SmtpClient.kt
@@ -138,6 +138,8 @@ class SmtpClient(
     @Volatile
     private var lastSendTime = 0L
 
+    private val session: Session by lazy { createSession() }
+
     /**
      * Sender en e-post.
      *
@@ -182,7 +184,6 @@ class SmtpClient(
         }
 
         return try {
-            val session = createSession()
             val mimeMessage = buildMimeMessage(session, message, customMessageId)
 
             sendLock.withLock {

--- a/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
+++ b/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
@@ -270,6 +270,24 @@ class SmtpClientTest {
     }
 
     @Nested
+    inner class SessionCaching {
+
+        @Test
+        fun `samme Session-instans gjenbrukes paa tvers av sendinger`() {
+            val (client, messages) = captureClient()
+
+            client.send(EmailMessage(to = "a@example.com", subject = "1", body = "1"))
+            client.send(EmailMessage(to = "b@example.com", subject = "2", body = "2"))
+
+            assertEquals(2, messages.size)
+            assertTrue(
+                messages[0].session === messages[1].session,
+                "Session skal gjenbrukes (samme instans) for aa unngaa unodvendig overhead"
+            )
+        }
+    }
+
+    @Nested
     inner class RateLimiting {
 
         @Test


### PR DESCRIPTION
Fixes #86

## Summary
- Cacher `jakarta.mail.Session` som `by lazy` i `SmtpClient` slik at den opprettes én gang og gjenbrukes paa tvers av sendinger.
- Session er immutable og thread-safe etter opprettelse, saa gjenbruk er trygt.
- Unngaar unodvendig allokering av `Properties` + `Session` per `doSend()`-kall. Relevant for apper med hoy e-posttrafikk (f.eks. biologportal).

## Test plan
- [x] Ny test `SessionCaching.samme Session-instans gjenbrukes paa tvers av sendinger` verifiserer at to paafoelgende `send()`-kall gir `MimeMessage`-objekter som peker til samme `Session`-instans.
- [x] Full grunnmur-testsuite kjort lokalt — alle groenne.
- [x] CI (Hurtigsjekk) groen paa branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)