### PR TITLE
Fix #87: document intentional fixed version strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,6 +373,18 @@ Apper sjekker ut grunnmur med `GRUNNMUR_TOKEN` secret:
 ./gradlew test     # Kjoer tester
 ```
 
+## Versjonsstrategi
+
+`build.gradle.kts` har `version = "1.0.0"` hardkodet med hensikt. Appene (lo-finans, biologportal, 6810, styreportal) konsumerer grunnmur via Gradle composite build (`includeBuild`) — ikke via Maven-koordinater. Sporbarhet skjer via git commit-hash, ikke versjonsnummer.
+
+`publishing`-blokken i `build.gradle.kts` eksisterer for fremtidig publisering til GitHub Packages, men er ikke i rutinemessig bruk. Versjonen bumpes kun manuelt ved breaking changes — ingen automatisk bump, ingen SNAPSHOT-konvensjon, ingen CHANGELOG.
+
+**Hvis rutinemessig publisering til GitHub Packages tas i bruk senere**, bytt til en av:
+- Dato-basert versjon: `version = "1.0.${LocalDate.now().format(YYYYMMDD)}"` (bumpes per release)
+- Git commit-hash suffix: `version = "1.0.0-${gitShortHash}"` (entydig per commit)
+
+Inntil da holdes versjonen fast. Dette er en bevisst avgjoerelse, ikke en glemt TODO.
+
 ## Viktig
 
 - Ved Dependabot-oppgraderinger: oppgrader grunnmur FOERST, deretter alle 4 apper til samme versjoner


### PR DESCRIPTION
Fixes #87

## Summary
- Dokumenterer at `version = "1.0.0"` i `build.gradle.kts` er en bevisst avgjoerelse, ikke tech-debt som skal fjernes.
- Konsumentappene (lo-finans, biologportal, 6810, styreportal) bruker composite build (`includeBuild`), ikke Maven-versjoner — sporbarhet skjer via git commit-hash.
- Beskriver alternativene (dato-basert, commit-hash suffix) hvis rutinemessig publisering til GitHub Packages tas i bruk senere.

## Hvorfor Alternativ C
Issue #87 foreslo tre alternativer. A og B krever endring av `build.gradle.kts`, men appene konsumerer ikke grunnmur via Maven — versjonsfeltet er i praksis ubrukt. Aa innfoere dato- eller hash-basert versjon nu gir kompleksitet for infrastruktur som ikke er i aktiv bruk. Dokumentasjon av intensjonen er den rette loesningen for gjeldende arkitektur.

## Test plan
- [x] Doc-only change — ingen kode er endret, ingen tester kreves
- [x] CI ignorerer `.md`-endringer per `paths-ignore` i begge workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)