### PR TITLE
ci: standardize triggers — push + pull_request

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -49,10 +49,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
           echo "Enabling auto-merge for PR #${PR_NUM} (actor=${{ github.actor }}, branch=${{ github.head_ref }})"
+          # --repo flagget gjor at gh ikke trenger en lokal git checkout. Uten
+          # det feilet workflowen tidligere med "not a git repository" siden
+          # vi ikke kjorer actions/checkout (unodig for ren API-operasjon).
           # `--auto` koer opp merge naar branch-protection-krav er oppfylt.
           # Hvis ingen branch-protection finnes, faller vi tilbake til umiddelbar
           # merge (forutsatt at PR er mergeable og CI groenn akkurat naa).
-          gh pr merge "$PR_NUM" --auto --merge --delete-branch \
-            || gh pr merge "$PR_NUM" --merge --delete-branch
+          gh pr merge "$PR_NUM" --repo "$REPO" --auto --merge --delete-branch \
+            || gh pr merge "$PR_NUM" --repo "$REPO" --merge --delete-branch

--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -1,6 +1,16 @@
 name: Fullstendig testsuite
 
 on:
+  push:
+    branches: [main, 'auto/**']
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'scripts/**'
+      - 'docker-compose*.yml'
+      - '.env*'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     branches: [main]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,16 @@ on:
       - '.env*'
       - 'LICENSE'
       - '.gitignore'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'scripts/**'
+      - 'docker-compose*.yml'
+      - '.env*'
+      - 'LICENSE'
+      - '.gitignore'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Standardiserer test.yml og test-full.yml til å trigge på BÅDE `push: [main, auto/**]` og `pull_request: [main]`. Erstatter `pull_request_target` med `pull_request` der det brukes.

**Hvorfor:** PR-er fra fix/, ci/, chore/ branches fikk ikke CI før merge — workflows triggret kun på push til main/auto/**. Etter denne endringen kjører hele CI-suiten på alle PR-er uavhengig av branch-prefix, slik at branch-protection og auto-merge fungerer konsistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)