### PR TITLE
ci: migrate test workflows to self-hosted NUC runners

### DIFF
--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -36,7 +36,7 @@ jobs:
   backend:
     name: Backend-tester
     if: github.actor != 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'ci:run')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, nuc]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -44,13 +44,6 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
       - name: Kjør alle backend-tester
         run: ./gradlew test --no-daemon
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   backend:
     name: Backend kompilering
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, nuc]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -40,12 +40,5 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
       - name: Kompiler backend
         run: ./gradlew compileKotlin compileTestKotlin --no-daemon


### PR DESCRIPTION
## Summary
- Bytte `runs-on: ubuntu-latest` → `runs-on: [self-hosted, linux, nuc]` på `test.yml` og `test-full.yml` (kun grunnmur-backend) / `test.yml` (kun grunnmur-frontend)
- Fjern `actions/cache@v5` for `~/.gradle/caches` (overflødig på self-hosted, $HOME persisterer mellom runs)
- 4 nye runners registrert på NUC 2026-04-27 (`nuc-runner-grunnmur-{backend,frontend}` + `-2`)

## Test plan
- [ ] CI grønn på denne PR-en (kjøres på de nye self-hosted runnerne)
- [ ] Ingen consumere (lo-finans/biologportal/6810/styreportal) påvirkes — de bruker grunnmur via `actions/checkout` + `GRUNNMUR_TOKEN`, ikke via grunnmurs egen CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)