### PR TITLE
Fix #106 QA: sterkere exception-type og norsk feilmelding

### DIFF
--- a/src/main/kotlin/no/grunnmur/GitHubAppAuth.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubAppAuth.kt
@@ -72,7 +72,11 @@ class GitHubAppAuth(
 
         val tokenResponse = json.decodeFromString<InstallationToken>(response.bodyAsText())
         cachedToken = tokenResponse.token
-        tokenExpiresAt = parseExpiresAt(tokenResponse.expires_at)
+        tokenExpiresAt = try {
+            parseExpiresAt(tokenResponse.expires_at)
+        } catch (e: java.time.format.DateTimeParseException) {
+            throw RuntimeException("Ugyldig expires_at-format fra GitHub: '${tokenResponse.expires_at}'", e)
+        }
         return tokenResponse.token
     }
 

--- a/src/test/kotlin/no/grunnmur/GitHubAppAuthTest.kt
+++ b/src/test/kotlin/no/grunnmur/GitHubAppAuthTest.kt
@@ -129,7 +129,7 @@ class GitHubAppAuthTest {
         @Test
         fun `parseExpiresAt kaster exception ved ugyldig format`() {
             val auth = GitHubAppAuth("123", testPrivateKey, "456")
-            assertFailsWith<Exception> {
+            assertFailsWith<java.time.format.DateTimeParseException> {
                 auth.parseExpiresAt("ugyldig-dato")
             }
         }


### PR DESCRIPTION
Oppfølging av #108 basert på QA-review.

- Stramme  til  i test
- Legger til norsk feilmelding ved ugyldig  fra GitHub API