### PR TITLE
Fix #107: align TotpService dev OTP code with OtpUtils convention

### DIFF
--- a/src/main/kotlin/no/grunnmur/TotpService.kt
+++ b/src/main/kotlin/no/grunnmur/TotpService.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit
 object TotpService {
     private val secureRandom = SecureRandom()
     private const val SECRET_BYTES = 20
-    private const val DEV_TOTP_CODE = "000000"
+    private const val DEV_TOTP_CODE = "123456"
     private const val TIME_STEP_SECONDS = 30
     private const val CODE_DIGITS = 6
     private const val WINDOW_SIZE = 2 // ±2 vinduer (2 min toleranse)
@@ -65,7 +65,7 @@ object TotpService {
      * @param encryptedSecret Kryptert hemmelighet fra databasen
      * @param encryptionKey 64 hex-tegn AES-256-nokkel
      * @param code 6-sifret TOTP-kode fra autentiserings-appen
-     * @param devMode Hvis true, aksepteres "000000" alltid (for utvikling)
+     * @param devMode Hvis true, aksepteres "123456" alltid (for utvikling — samme som OtpUtils.DEV_CODE)
      * @return true hvis koden er gyldig
      */
     fun verifyTotp(

--- a/src/test/kotlin/no/grunnmur/TotpServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/TotpServiceTest.kt
@@ -96,11 +96,19 @@ class TotpServiceTest {
     @Nested
     inner class VerifyTotp {
         @Test
-        fun `dev-modus godtar 000000`() {
+        fun `dev-modus godtar 123456`() {
             val secretBytes = ByteArray(20) { it.toByte() }
             val encryptedSecret = encryptedSecretFrom(secretBytes)
 
-            assertTrue(TotpService.verifyTotp(encryptedSecret, testKey, "000000", devMode = true))
+            assertTrue(TotpService.verifyTotp(encryptedSecret, testKey, "123456", devMode = true))
+        }
+
+        @Test
+        fun `dev-modus avviser 000000`() {
+            val secretBytes = ByteArray(20) { it.toByte() }
+            val encryptedSecret = encryptedSecretFrom(secretBytes)
+
+            assertFalse(TotpService.verifyTotp(encryptedSecret, testKey, "000000", devMode = true))
         }
 
         @Test


### PR DESCRIPTION
Fixes #107

Endrer `DEV_TOTP_CODE` fra `"000000"` til `"123456"` i `TotpService` for å samsvare med `OtpUtils.DEV_CODE`-konvensjonen.