### PR TITLE
Fix #115: Gjør RateLimiter.isAllowed() atomisk med compute()

### DIFF
--- a/src/main/kotlin/no/grunnmur/RateLimiter.kt
+++ b/src/main/kotlin/no/grunnmur/RateLimiter.kt
@@ -38,19 +38,24 @@ class RateLimiter(
         val now = System.currentTimeMillis()
         cleanup(now)
 
-        val record = attempts[key]
-
-        if (record == null || now - record.windowStart > windowMs) {
-            attempts[key] = AttemptRecord(1, now)
-            return true
+        var allowed = false
+        attempts.compute(key) { _, record ->
+            when {
+                record == null || now - record.windowStart > windowMs -> {
+                    allowed = true
+                    AttemptRecord(1, now)
+                }
+                record.count >= maxAttempts -> {
+                    allowed = false
+                    record
+                }
+                else -> {
+                    allowed = true
+                    record.copy(count = record.count + 1)
+                }
+            }
         }
-
-        if (record.count >= maxAttempts) {
-            return false
-        }
-
-        attempts[key] = record.copy(count = record.count + 1)
-        return true
+        return allowed
     }
 
     /**
@@ -103,17 +108,17 @@ class RateLimiter(
      */
     fun size(): Int = attempts.size
 
-    @Synchronized
     private fun cleanup(now: Long) {
         if (now - lastCleanup < cleanupIntervalMs) return
-        lastCleanup = now
-
-        attempts.entries.removeIf { now - it.value.windowStart > windowMs }
-
-        if (attempts.size > maxEntries) {
-            val sorted = attempts.entries.sortedBy { it.value.windowStart }
-            val toRemove = sorted.take(attempts.size - maxEntries)
-            toRemove.forEach { attempts.remove(it.key) }
+        synchronized(this) {
+            if (now - lastCleanup < cleanupIntervalMs) return
+            attempts.entries.removeIf { now - it.value.windowStart > windowMs }
+            if (attempts.size > maxEntries) {
+                val sorted = attempts.entries.sortedBy { it.value.windowStart }
+                val toRemove = sorted.take(attempts.size - maxEntries)
+                toRemove.forEach { attempts.remove(it.key) }
+            }
+            lastCleanup = now
         }
     }
 }

--- a/src/test/kotlin/no/grunnmur/RateLimiterTest.kt
+++ b/src/test/kotlin/no/grunnmur/RateLimiterTest.kt
@@ -1,6 +1,10 @@
 package no.grunnmur
 
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -99,6 +103,31 @@ class RateLimiterTest {
 
         limiter.isAllowed("key1")
         assertEquals(0, limiter.remainingAttempts("key1"))
+    }
+
+    @Test
+    fun `isAllowed er atomisk under parallell last`() {
+        val maxAttempts = 100
+        val threadCount = 50
+        val callsPerThread = 20
+        val limiter = RateLimiter(maxAttempts = maxAttempts, windowMs = 60_000)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val barrier = CyclicBarrier(threadCount)
+        val granted = AtomicInteger(0)
+
+        val futures = (1..threadCount).map {
+            executor.submit {
+                barrier.await()
+                repeat(callsPerThread) {
+                    if (limiter.isAllowed("shared-key")) granted.incrementAndGet()
+                }
+            }
+        }
+        futures.forEach { it.get(10, TimeUnit.SECONDS) }
+        executor.shutdown()
+
+        assertEquals(maxAttempts, granted.get(),
+            "isAllowed skal aldri tillate flere enn maxAttempts under parallell last")
     }
 
     @Test


### PR DESCRIPTION
Fixes #115

## Endringer
-  bruker nå  for atomisk read-check-write. Eliminerer race condition der samtidige tråder kunne overstige .
-  bruker nå double-check locking for å eliminere monitor-overhead i hot-path (idempotent sjekk av  skjer lock-free, lås tas kun ved faktisk cleanup).

## Test lagt til
- : 50 tråder × 20 kall = 1000 forsøk mot én nøkkel med . Verifiserer at nøyaktig 100 returnerer  under høy parallell last.