### PR TITLE
Fix #112: decouple STARTTLS from requireAuth in SmtpConfig

### DIFF
--- a/src/main/kotlin/no/grunnmur/SmtpClient.kt
+++ b/src/main/kotlin/no/grunnmur/SmtpClient.kt
@@ -21,6 +21,7 @@ import kotlin.concurrent.withLock
  * @param from Avsender-e-postadresse
  * @param fromName Avsendernavn (vises i e-postklient)
  * @param requireAuth Om SMTP-autentisering kreves
+ * @param startTls Om STARTTLS skal aktiveres (uavhengig av requireAuth, default true)
  * @param devMode I dev-modus logges e-post i stedet for aa sendes
  * @param timeoutMs Timeout for SMTP-tilkobling og sending (default 10s)
  * @param minIntervalMs Minimum intervall mellom sendinger i ms (rate limiting, default 100ms)
@@ -33,6 +34,7 @@ data class SmtpConfig(
     val from: String,
     val fromName: String = "",
     val requireAuth: Boolean = true,
+    val startTls: Boolean = true,
     val devMode: Boolean = false,
     val timeoutMs: Int = 10_000,
     val minIntervalMs: Long = 100
@@ -218,7 +220,7 @@ class SmtpClient(
             put("mail.smtp.host", config.host)
             put("mail.smtp.port", config.port.toString())
             put("mail.smtp.auth", config.requireAuth.toString())
-            put("mail.smtp.starttls.enable", config.requireAuth.toString())
+            put("mail.smtp.starttls.enable", config.startTls.toString())
             put("mail.smtp.connectiontimeout", config.timeoutMs.toString())
             put("mail.smtp.timeout", config.timeoutMs.toString())
             put("mail.smtp.writetimeout", config.timeoutMs.toString())

--- a/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
+++ b/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
@@ -398,13 +398,14 @@ class SmtpClientTest {
 
             assertEquals("", config.fromName)
             assertTrue(config.requireAuth)
+            assertTrue(config.startTls)
             assertFalse(config.devMode)
             assertEquals(10_000, config.timeoutMs)
             assertEquals(100L, config.minIntervalMs)
         }
 
         @Test
-        fun `send med requireAuth false fungerer uten STARTTLS`() {
+        fun `send med requireAuth false sender uten autentisering`() {
             val noAuthConfig = testConfig.copy(requireAuth = false)
             val messages = mutableListOf<MimeMessage>()
             val client = SmtpClient(noAuthConfig) { mime -> messages.add(mime) }
@@ -415,8 +416,36 @@ class SmtpClientTest {
                 body = "Din kode er 123456"
             ))
 
-            assertTrue(result.success, "Skal kunne sende uten auth/STARTTLS")
+            assertTrue(result.success, "Skal kunne sende uten autentisering")
             assertEquals(1, messages.size)
+        }
+
+        @Test
+        fun `STARTTLS er aktivert uavhengig av requireAuth`() {
+            val noAuthConfig = testConfig.copy(requireAuth = false)
+            val messages = mutableListOf<MimeMessage>()
+            val client = SmtpClient(noAuthConfig) { mime -> messages.add(mime) }
+
+            client.send(EmailMessage(to = "biolog@example.com", subject = "Test", body = "Test"))
+
+            val sessionProps = messages.first().session.properties
+            assertEquals("true", sessionProps["mail.smtp.starttls.enable"],
+                "STARTTLS skal vaere aktivert selv naar requireAuth=false")
+            assertEquals("false", sessionProps["mail.smtp.auth"],
+                "Auth skal vaere deaktivert naar requireAuth=false")
+        }
+
+        @Test
+        fun `startTls false deaktiverer STARTTLS uavhengig av requireAuth`() {
+            val noTlsConfig = testConfig.copy(startTls = false)
+            val messages = mutableListOf<MimeMessage>()
+            val client = SmtpClient(noTlsConfig) { mime -> messages.add(mime) }
+
+            client.send(EmailMessage(to = "relay@example.com", subject = "Test", body = "Test"))
+
+            val sessionProps = messages.first().session.properties
+            assertEquals("false", sessionProps["mail.smtp.starttls.enable"],
+                "STARTTLS skal vaere deaktivert naar startTls=false")
         }
 
         @Test


### PR DESCRIPTION
Fixes #112

Legger til  som separat parameter i . STARTTLS og autentisering er ortogonale konsepter — en intern relay kan kreve TLS uten autentisering, og SSL-on-connect (port 465) er uavhengig av auth.

Standardverdi  gir bakoverkompatibilitet for alle eksisterende konfigurasjoner.