### PR TITLE
Fix #122: SmtpConfig.fromEnv() med SMTP_STARTTLS-støtte

### DIFF
--- a/src/main/kotlin/no/grunnmur/SmtpClient.kt
+++ b/src/main/kotlin/no/grunnmur/SmtpClient.kt
@@ -38,7 +38,23 @@ data class SmtpConfig(
     val devMode: Boolean = false,
     val timeoutMs: Int = 10_000,
     val minIntervalMs: Long = 100
-)
+) {
+    companion object {
+        fun fromEnv(getEnv: (String) -> String? = System::getenv): SmtpConfig = SmtpConfig(
+            host = requireNotNull(getEnv("SMTP_HOST")) { "SMTP_HOST er påkrevd" },
+            port = getEnv("SMTP_PORT")?.toInt() ?: 587,
+            user = requireNotNull(getEnv("SMTP_USER")) { "SMTP_USER er påkrevd" },
+            password = requireNotNull(getEnv("SMTP_PASSWORD")) { "SMTP_PASSWORD er påkrevd" },
+            from = requireNotNull(getEnv("SMTP_FROM")) { "SMTP_FROM er påkrevd" },
+            fromName = getEnv("SMTP_FROM_NAME") ?: "",
+            requireAuth = getEnv("SMTP_REQUIRE_AUTH")?.toBoolean() ?: true,
+            startTls = getEnv("SMTP_STARTTLS")?.toBoolean() ?: true,
+            devMode = getEnv("SMTP_DEV_MODE")?.toBoolean() ?: false,
+            timeoutMs = getEnv("SMTP_TIMEOUT_MS")?.toInt() ?: 10_000,
+            minIntervalMs = getEnv("SMTP_MIN_INTERVAL_MS")?.toLong() ?: 100
+        )
+    }
+}
 
 /**
  * E-postmelding som skal sendes.

--- a/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
+++ b/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
@@ -5,10 +5,11 @@ import jakarta.mail.internet.MimeMultipart
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.test.assertFalse
 
 class SmtpClientTest {
 
@@ -380,6 +381,69 @@ class SmtpClientTest {
             val mixed = mime.content as MimeMultipart
             assertTrue(mixed.contentType.contains("mixed"))
             assertEquals(2, mixed.count, "Skal ha body-del + 1 vedlegg")
+        }
+    }
+
+    @Nested
+    inner class FromEnv {
+
+        private val baseEnv = mapOf(
+            "SMTP_HOST" to "postfix",
+            "SMTP_USER" to "bruker",
+            "SMTP_PASSWORD" to "passord",
+            "SMTP_FROM" to "noreply@example.com"
+        )
+
+        @Test
+        fun `fromEnv returnerer startTls true som default`() {
+            val config = SmtpConfig.fromEnv { baseEnv[it] }
+            assertTrue(config.startTls, "startTls skal vaere true naar SMTP_STARTTLS ikke er satt")
+        }
+
+        @Test
+        fun `fromEnv leser SMTP_STARTTLS false`() {
+            val env = baseEnv + mapOf("SMTP_STARTTLS" to "false")
+            val config = SmtpConfig.fromEnv { env[it] }
+            assertFalse(config.startTls, "startTls skal vaere false naar SMTP_STARTTLS=false")
+        }
+
+        @Test
+        fun `fromEnv leser SMTP_STARTTLS true eksplisitt`() {
+            val env = baseEnv + mapOf("SMTP_STARTTLS" to "true")
+            val config = SmtpConfig.fromEnv { env[it] }
+            assertTrue(config.startTls, "startTls skal vaere true naar SMTP_STARTTLS=true")
+        }
+
+        @Test
+        fun `fromEnv kaster feil naar paakrevd env-var mangler`() {
+            val incompleteEnv = mapOf("SMTP_HOST" to "postfix")
+            assertFailsWith<IllegalArgumentException> {
+                SmtpConfig.fromEnv { incompleteEnv[it] }
+            }
+        }
+
+        @Test
+        fun `fromEnv leser alle SMTP-env-vars`() {
+            val env = baseEnv + mapOf(
+                "SMTP_PORT" to "25",
+                "SMTP_FROM_NAME" to "Min App",
+                "SMTP_REQUIRE_AUTH" to "false",
+                "SMTP_DEV_MODE" to "true",
+                "SMTP_TIMEOUT_MS" to "5000",
+                "SMTP_MIN_INTERVAL_MS" to "200"
+            )
+            val config = SmtpConfig.fromEnv { env[it] }
+
+            assertEquals("postfix", config.host)
+            assertEquals(25, config.port)
+            assertEquals("bruker", config.user)
+            assertEquals("passord", config.password)
+            assertEquals("noreply@example.com", config.from)
+            assertEquals("Min App", config.fromName)
+            assertFalse(config.requireAuth)
+            assertTrue(config.devMode)
+            assertEquals(5000, config.timeoutMs)
+            assertEquals(200L, config.minIntervalMs)
         }
     }
 


### PR DESCRIPTION
Fixes #122