### PR TITLE
Fix #125: sett mail.smtp.starttls.required for å hindre plaintext-fallback

### DIFF
--- a/src/main/kotlin/no/grunnmur/SmtpClient.kt
+++ b/src/main/kotlin/no/grunnmur/SmtpClient.kt
@@ -237,6 +237,7 @@ class SmtpClient(
             put("mail.smtp.port", config.port.toString())
             put("mail.smtp.auth", config.requireAuth.toString())
             put("mail.smtp.starttls.enable", config.startTls.toString())
+            put("mail.smtp.starttls.required", config.startTls.toString())
             put("mail.smtp.connectiontimeout", config.timeoutMs.toString())
             put("mail.smtp.timeout", config.timeoutMs.toString())
             put("mail.smtp.writetimeout", config.timeoutMs.toString())

--- a/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
+++ b/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
@@ -513,6 +513,32 @@ class SmtpClientTest {
         }
 
         @Test
+        fun `startTls true setter starttls required til true`() {
+            val tlsConfig = testConfig.copy(startTls = true)
+            val messages = mutableListOf<MimeMessage>()
+            val client = SmtpClient(tlsConfig) { mime -> messages.add(mime) }
+
+            client.send(EmailMessage(to = "ekstern@example.com", subject = "Test", body = "Test"))
+
+            val sessionProps = messages.first().session.properties
+            assertEquals("true", sessionProps["mail.smtp.starttls.required"],
+                "STARTTLS required skal vaere true for aa hindre fallback til ukryptert")
+        }
+
+        @Test
+        fun `startTls false setter starttls required til false`() {
+            val noTlsConfig = testConfig.copy(startTls = false)
+            val messages = mutableListOf<MimeMessage>()
+            val client = SmtpClient(noTlsConfig) { mime -> messages.add(mime) }
+
+            client.send(EmailMessage(to = "intern@example.com", subject = "Test", body = "Test"))
+
+            val sessionProps = messages.first().session.properties
+            assertEquals("false", sessionProps["mail.smtp.starttls.required"],
+                "STARTTLS required skal vaere false naar startTls=false (intern postfix)")
+        }
+
+        @Test
         fun `EmailAttachment equals og hashCode fungerer med ByteArray`() {
             val a = EmailAttachment("test.txt", "hello".toByteArray(), "text/plain")
             val b = EmailAttachment("test.txt", "hello".toByteArray(), "text/plain")


### PR DESCRIPTION
Fixes #125

Setter `mail.smtp.starttls.required` lik `config.startTls` i `createSession()`. Uten denne property-en kan Jakarta Mail falle tilbake til ukryptert forbindelse dersom STARTTLS-forhandlingen feiler (f.eks. MITM som fjerner STARTTLS fra EHLO).