### PR TITLE
Fix #133: oppdater konsumentliste i CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # grunnmur
 
 Felles Kotlin-bibliotek for alle Ktor-apper i portefoljen.
-Brukes av lo-finans, biologportal, 6810 og summa-summarum.
+Brukes av lo-finans, biologportal, 6810 og styreportal.
 
 Sist oppdatert: 2026-05-07
 


### PR DESCRIPTION
Fixes #133

Erstatter `summa-summarum` med `styreportal` på linje 4 i CLAUDE.md, slik at
listen matcher aktiv portefølje og §Versjonsstrategi-seksjonen.