### PR TITLE
ci: add test-full-skip.yml passthrough for doc-only PRs

### DIFF
--- a/.github/workflows/test-full-skip.yml
+++ b/.github/workflows/test-full-skip.yml
@@ -1,0 +1,32 @@
+name: Fullstendig testsuite (doc-only skip)
+
+# Passthrough-workflow for doc-only PRs. test-full.yml har
+# paths-ignore: **.md/docs/**/scripts/** osv. — paa rene dokumentasjons-PRs
+# trigger den ikke, men branch protection krever 'Backend-tester' som
+# required check. Resultat: doc-PRs henger evig.
+#
+# Denne workflowen trigger PAA samme paths-listen (motsatt) og produserer
+# en check med samme NAVN — branch protection er fornoyd, PR kan auto-merge.
+# Refs misc-scripts#342.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'scripts/**'
+      - 'docker-compose*.yml'
+      - '.env*'
+      - 'LICENSE'
+      - '.gitignore'
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend-tester
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Doc-only PR — bestaatt (ingen testing noedvendig)"


### PR DESCRIPTION
## Summary
- Legger til `.github/workflows/test-full-skip.yml` som produserer `Backend-tester`-check pa rene doc/script-PRs
- Eksisterende `test-full.yml` skipper disse pga `paths-ignore`, men branch protection krever fortsatt sjekken — PR-er henger evig
- Samme passthrough-moenster brukt i biologportal/lo-finans/6810/styreportal siden 2026-04-29

## Bakgrunn
PR #135 (Fix #133: konsumentliste i CLAUDE.md) har vaert blokkert i 13+ timer fordi `Backend-tester` aldri trigger pa `**.md`-only endring. Denne PR-en loeser problemet systemisk.

## Test plan
- [ ] Denne PR-en (endrer `.github/workflows/`) trigger `Backend-tester` via `test-full.yml` siden `.github/**` IKKE er i paths-ignore
- [ ] Etter merge: PR #135 rebases mot main, far Backend-tester-check via passthrough, auto-merger

🤖 Generated with [Claude Code](https://claude.com/claude-code)