### PR TITLE
Fix #143: AuditLogTable.entityId Int? → Long?

### DIFF
--- a/src/main/kotlin/no/grunnmur/AuditLogService.kt
+++ b/src/main/kotlin/no/grunnmur/AuditLogService.kt
@@ -32,7 +32,7 @@ class AuditLogService {
         userEmail: String = "system",
         action: String,
         entityType: String,
-        entityId: Int? = null,
+        entityId: Long? = null,
         details: String? = null,
         ipAddress: String? = null
     ) {
@@ -165,7 +165,7 @@ data class AuditLogEntry(
     val userEmail: String,
     val action: String,
     val entityType: String,
-    val entityId: Int?,
+    val entityId: Long?,
     val details: String?,
     val ipAddress: String?,
     val timestamp: String

--- a/src/main/kotlin/no/grunnmur/AuditLogTable.kt
+++ b/src/main/kotlin/no/grunnmur/AuditLogTable.kt
@@ -15,7 +15,7 @@ import org.jetbrains.exposed.v1.javatime.datetime
  *     user_email VARCHAR(255) NOT NULL DEFAULT 'system',
  *     action VARCHAR(100) NOT NULL,
  *     entity_type VARCHAR(100) NOT NULL,
- *     entity_id INTEGER,
+ *     entity_id BIGINT,
  *     details TEXT,
  *     ip_address VARCHAR(45),
  *     created_at TIMESTAMP NOT NULL DEFAULT NOW()
@@ -31,7 +31,7 @@ object AuditLogs : Table("audit_logs") {
     val userEmail = varchar("user_email", 255).default("system")
     val action = varchar("action", 100)
     val entityType = varchar("entity_type", 100)
-    val entityId = integer("entity_id").nullable()
+    val entityId = long("entity_id").nullable()
     val details = text("details").nullable()
     val ipAddress = varchar("ip_address", 45).nullable()
     val createdAt = datetime("created_at").clientDefault { TimeUtils.nowOslo() }

--- a/src/test/kotlin/no/grunnmur/AuditLogServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/AuditLogServiceTest.kt
@@ -73,7 +73,7 @@ class AuditLogServiceTest {
             assertEquals("admin@test.no", e.userEmail)
             assertEquals("CREATE", e.action)
             assertEquals("USER", e.entityType)
-            assertEquals(42, e.entityId)
+            assertEquals(42L, e.entityId)
             assertEquals("Opprettet bruker", e.details)
             assertEquals("10.0.0.1", e.ipAddress)
         }
@@ -97,6 +97,21 @@ class AuditLogServiceTest {
             assertNull(entries[0].entityId)
             assertNull(entries[0].details)
             assertNull(entries[0].ipAddress)
+        }
+
+        @Test
+        fun `log bevarer entityId stoerre enn Int MAX VALUE`() {
+            val bigId = Int.MAX_VALUE + 1L
+            service.log(
+                userId = 1,
+                action = "CREATE",
+                entityType = "ENTITY",
+                entityId = bigId
+            )
+
+            val entries = service.findAll()
+            assertEquals(1, entries.size)
+            assertEquals(bigId, entries[0].entityId)
         }
 
         @Test


### PR DESCRIPTION
Fixes #143

## Endringer
- `AuditLogTable.entityId`: `integer("entity_id")` → `long("entity_id")` (PostgreSQL `BIGINT`)
- `AuditLogService.log()`: parameter `entityId: Int?` → `entityId: Long?`
- `AuditLogEntry`: felt `entityId: Int?` → `entityId: Long?`
- SQL-kommentar i `AuditLogTable.kt` oppdatert til `BIGINT`

## DB-migrering (konsumerende apper)
Alle apper som bruker `audit_logs`-tabellen må kjøre:
```sql
ALTER TABLE audit_logs ALTER COLUMN entity_id TYPE BIGINT;
```

## Test
Ny test: `log bevarer entityId stoerre enn Int MAX VALUE` — verifiserer at Long-verdi > 2,1 mrd lagres og leses korrekt.