### PR TITLE
Fix #142: log warning when image cleanup fails silently

### DIFF
--- a/src/main/kotlin/no/grunnmur/ImageUploadService.kt
+++ b/src/main/kotlin/no/grunnmur/ImageUploadService.kt
@@ -1,5 +1,6 @@
 package no.grunnmur
 
+import org.slf4j.LoggerFactory
 import java.nio.file.Path
 import java.util.UUID
 import kotlin.io.path.*
@@ -19,6 +20,8 @@ import kotlin.io.path.*
  * ```
  */
 class ImageUploadService(private val config: Config) {
+
+    private val logger = LoggerFactory.getLogger(ImageUploadService::class.java)
 
     data class Config(
         val uploadDir: String,
@@ -73,7 +76,10 @@ class ImageUploadService(private val config: Config) {
     fun deleteIssueImages(issueNumber: Int) {
         val issueDir = Path.of(config.uploadDir, config.repoSlug, issueNumber.toString())
         if (issueDir.exists()) {
-            issueDir.toFile().deleteRecursively()
+            val deleted = issueDir.toFile().deleteRecursively()
+            if (!deleted) {
+                logger.warn("Kunne ikke slette bildemappe for issue #$issueNumber: ${issueDir.toAbsolutePath()}")
+            }
         }
     }
 
@@ -86,7 +92,10 @@ class ImageUploadService(private val config: Config) {
             if (dir.isDirectory()) {
                 val issueNumber = dir.name.toIntOrNull()
                 if (issueNumber != null && issueNumber !in openIssueNumbers) {
-                    dir.toFile().deleteRecursively()
+                    val deleted = dir.toFile().deleteRecursively()
+                    if (!deleted) {
+                        logger.warn("Kunne ikke slette bildemappe for lukket issue #$issueNumber: ${dir.toAbsolutePath()}")
+                    }
                 }
             }
         }

--- a/src/test/kotlin/no/grunnmur/ImageUploadServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/ImageUploadServiceTest.kt
@@ -251,5 +251,41 @@ class ImageUploadServiceTest {
             // Skal ikke kaste exception
             service.cleanupClosedIssues(openIssueNumbers = setOf(1))
         }
+
+        @Test
+        fun `cleanupClosedIssues kaster ikke exception ved mislykket sletting`() {
+            val service = createService()
+            service.uploadImage(2, pngBytes(), "b.png")
+
+            val repoDir = tempDir.resolve("test-repo")
+            repoDir.toFile().setReadOnly()
+
+            try {
+                // Skal ikke kaste exception selv om sletting feiler
+                service.cleanupClosedIssues(openIssueNumbers = setOf(1))
+                // Mappen eksisterer fortsatt fordi sletting mislyktes
+                assertTrue(repoDir.resolve("2").exists())
+            } finally {
+                repoDir.toFile().setWritable(true)
+            }
+        }
+
+        @Test
+        fun `deleteIssueImages kaster ikke exception ved mislykket sletting`() {
+            val service = createService()
+            service.uploadImage(1, pngBytes(), "a.png")
+
+            val repoDir = tempDir.resolve("test-repo")
+            repoDir.toFile().setReadOnly()
+
+            try {
+                // Skal ikke kaste exception selv om sletting feiler
+                service.deleteIssueImages(1)
+                // Mappen eksisterer fortsatt fordi sletting mislyktes
+                assertTrue(repoDir.resolve("1").exists())
+            } finally {
+                repoDir.toFile().setWritable(true)
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #142