### PR TITLE
Fix #140: replace RuntimeException with GitHubApiException in GitHub API calls

### DIFF
--- a/src/main/kotlin/no/grunnmur/Exceptions.kt
+++ b/src/main/kotlin/no/grunnmur/Exceptions.kt
@@ -32,3 +32,14 @@ class RateLimitException(
  * Handteres av StatusPages -> 401 Unauthorized.
  */
 class AuthenticationException(message: String = "Autentisering feilet") : Exception(message)
+
+/**
+ * Exception for feil ved kall mot GitHub API.
+ * Kastes av GitHubAppAuth og GitHubIssueService ved 4xx/5xx-svar fra GitHub,
+ * samt ved parsefeil i respons (statusCode = null).
+ */
+open class GitHubApiException(
+    message: String,
+    val statusCode: Int? = null,
+    cause: Throwable? = null
+) : Exception(message, cause)

--- a/src/main/kotlin/no/grunnmur/GitHubAppAuth.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubAppAuth.kt
@@ -23,7 +23,8 @@ import java.util.Base64
 open class GitHubAppAuth(
     private val appId: String,
     private val privateKeyPem: String,
-    private val installationId: String
+    private val installationId: String,
+    internal val baseUrl: String = "https://api.github.com"
 ) : Closeable {
     @Serializable
     private data class InstallationToken(
@@ -65,14 +66,14 @@ open class GitHubAppAuth(
     protected open suspend fun refreshToken(): String {
         val jwt = createJwt()
 
-        val response = client.post("https://api.github.com/app/installations/$installationId/access_tokens") {
+        val response = client.post("$baseUrl/app/installations/$installationId/access_tokens") {
             header("Authorization", "Bearer $jwt")
             header("Accept", "application/vnd.github+json")
         }
 
         if (!response.status.isSuccess()) {
             val errorBody = response.bodyAsText()
-            throw RuntimeException("Kunne ikke hente installation token: ${response.status} — $errorBody")
+            throw GitHubApiException("Kunne ikke hente installation token: ${response.status} — $errorBody", response.status.value)
         }
 
         val tokenResponse = json.decodeFromString<InstallationToken>(response.bodyAsText())
@@ -80,7 +81,7 @@ open class GitHubAppAuth(
         tokenExpiresAt = try {
             parseExpiresAt(tokenResponse.expires_at)
         } catch (e: java.time.format.DateTimeParseException) {
-            throw RuntimeException("Ugyldig expires_at-format fra GitHub: '${tokenResponse.expires_at}'", e)
+            throw GitHubApiException("Ugyldig expires_at-format fra GitHub: '${tokenResponse.expires_at}'", null, e)
         }
         return tokenResponse.token
     }

--- a/src/main/kotlin/no/grunnmur/GitHubIssueService.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueService.kt
@@ -19,7 +19,10 @@ import java.io.Closeable
  * - **PAT**: Personlig access token (Config med token)
  * - **GitHub App**: Installation token via JWT (Config med appAuth)
  */
-class GitHubIssueService(private val config: Config) : Closeable {
+class GitHubIssueService(
+    private val config: Config,
+    internal val apiBaseUrl: String = "https://api.github.com"
+) : Closeable {
 
     data class Config(
         val token: String? = null,
@@ -142,7 +145,7 @@ class GitHubIssueService(private val config: Config) : Closeable {
         )
 
         val authToken = getAuthToken()
-        val response = client.post("https://api.github.com/repos/${config.repo}/issues") {
+        val response = client.post("$apiBaseUrl/repos/${config.repo}/issues") {
             header("Authorization", "Bearer $authToken")
             header("Accept", "application/vnd.github+json")
             header("X-GitHub-Api-Version", GITHUB_API_VERSION)
@@ -152,7 +155,7 @@ class GitHubIssueService(private val config: Config) : Closeable {
 
         if (!response.status.isSuccess()) {
             val errorBody = response.bodyAsText()
-            throw RuntimeException("Kunne ikke opprette GitHub Issue: ${response.status} — $errorBody")
+            throw GitHubApiException("Kunne ikke opprette GitHub Issue: ${response.status} — $errorBody", response.status.value)
         }
 
         return json.decodeFromString<GitHubIssueResponse>(response.bodyAsText())
@@ -164,7 +167,7 @@ class GitHubIssueService(private val config: Config) : Closeable {
      */
     suspend fun updateIssueBody(issueNumber: Int, body: String) {
         val authToken = getAuthToken()
-        val response = client.patch("https://api.github.com/repos/${config.repo}/issues/$issueNumber") {
+        val response = client.patch("$apiBaseUrl/repos/${config.repo}/issues/$issueNumber") {
             header("Authorization", "Bearer $authToken")
             header("Accept", "application/vnd.github+json")
             header("X-GitHub-Api-Version", GITHUB_API_VERSION)
@@ -174,7 +177,7 @@ class GitHubIssueService(private val config: Config) : Closeable {
 
         if (!response.status.isSuccess()) {
             val errorBody = response.bodyAsText()
-            throw RuntimeException("Kunne ikke oppdatere GitHub Issue #$issueNumber: ${response.status} — $errorBody")
+            throw GitHubApiException("Kunne ikke oppdatere GitHub Issue #$issueNumber: ${response.status} — $errorBody", response.status.value)
         }
     }
 }

--- a/src/test/kotlin/no/grunnmur/GitHubAppAuthTest.kt
+++ b/src/test/kotlin/no/grunnmur/GitHubAppAuthTest.kt
@@ -1,11 +1,13 @@
 package no.grunnmur
 
+import com.sun.net.httpserver.HttpServer
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.Closeable
+import java.net.InetSocketAddress
 import java.util.Base64
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
@@ -149,6 +151,57 @@ class GitHubAppAuthTest {
             auth.close()
             // Skal vaere idempotent
             auth.close()
+        }
+    }
+
+    @Nested
+    inner class GitHubApiExceptionKasting {
+
+        @Test
+        fun `refreshToken kaster GitHubApiException ved HTTP-feil fra GitHub`() = runBlocking {
+            val server = HttpServer.create(InetSocketAddress(0), 0)
+            server.createContext("/app/installations/789/access_tokens") { exchange ->
+                exchange.requestBody.use { it.readBytes() }
+                val body = """{"message":"Bad credentials"}""".toByteArray()
+                exchange.sendResponseHeaders(401, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+            val port = server.address.port
+            try {
+                val auth = GitHubAppAuth("123456", testPrivateKey, "789", "http://localhost:$port")
+                val exception = assertFailsWith<GitHubApiException> {
+                    auth.getToken()
+                }
+                assertEquals(401, exception.statusCode)
+                assertContains(exception.message!!, "401")
+            } finally {
+                server.stop(0)
+            }
+        }
+
+        @Test
+        fun `refreshToken kaster GitHubApiException med null statusCode ved ugyldig expires_at-format`() = runBlocking {
+            val server = HttpServer.create(InetSocketAddress(0), 0)
+            server.createContext("/app/installations/789/access_tokens") { exchange ->
+                exchange.requestBody.use { it.readBytes() }
+                val body = """{"token":"test-token","expires_at":"ikke-en-dato"}""".toByteArray()
+                exchange.sendResponseHeaders(201, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+            val port = server.address.port
+            try {
+                val auth = GitHubAppAuth("123456", testPrivateKey, "789", "http://localhost:$port")
+                val exception = assertFailsWith<GitHubApiException> {
+                    auth.getToken()
+                }
+                assertEquals(null, exception.statusCode)
+                assertContains(exception.message!!, "ikke-en-dato")
+                assertTrue(exception.cause is java.time.format.DateTimeParseException)
+            } finally {
+                server.stop(0)
+            }
         }
     }
 

--- a/src/test/kotlin/no/grunnmur/GitHubIssueServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/GitHubIssueServiceTest.kt
@@ -1,9 +1,14 @@
 package no.grunnmur
 
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.Closeable
+import java.net.InetSocketAddress
 import kotlin.test.assertEquals
 import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -193,6 +198,54 @@ class GitHubIssueServiceTest {
         assertContains(updatedBody, "### Vedlegg")
         assertContains(updatedBody, "![abc-123.png](https://example.com/uploads/issues/biologportal/42/abc-123.png)")
         assertContains(updatedBody, "![def-456.jpg](https://example.com/uploads/issues/biologportal/42/def-456.jpg)")
+    }
+
+    @Nested
+    inner class GitHubApiExceptionKasting {
+
+        @Test
+        fun `createIssue kaster GitHubApiException ved 4xx-respons fra GitHub`() = runBlocking {
+            val server = HttpServer.create(InetSocketAddress(0), 0)
+            server.createContext("/repos/TestOrg/test-repo/issues") { exchange ->
+                exchange.requestBody.use { it.readBytes() }
+                val body = """{"message":"Validation Failed"}""".toByteArray()
+                exchange.sendResponseHeaders(422, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+            val port = server.address.port
+            try {
+                val testService = GitHubIssueService(config, "http://localhost:$port")
+                val exception = assertFailsWith<GitHubApiException> {
+                    testService.createIssue("Tittel", "Sender", "sender@test.com", "Beskrivelse")
+                }
+                assertEquals(422, exception.statusCode)
+            } finally {
+                server.stop(0)
+            }
+        }
+
+        @Test
+        fun `updateIssueBody kaster GitHubApiException ved 4xx-respons fra GitHub`() = runBlocking {
+            val server = HttpServer.create(InetSocketAddress(0), 0)
+            server.createContext("/repos/TestOrg/test-repo/issues/42") { exchange ->
+                exchange.requestBody.use { it.readBytes() }
+                val body = """{"message":"Not Found"}""".toByteArray()
+                exchange.sendResponseHeaders(404, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+            val port = server.address.port
+            try {
+                val testService = GitHubIssueService(config, "http://localhost:$port")
+                val exception = assertFailsWith<GitHubApiException> {
+                    testService.updateIssueBody(42, "Oppdatert innhold")
+                }
+                assertEquals(404, exception.statusCode)
+            } finally {
+                server.stop(0)
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #140

Adds `GitHubApiException(message, statusCode: Int? = null, cause: Throwable? = null)` to `Exceptions.kt` — consumers can now catch GitHub API errors distinctly from generic exceptions.

Replaces all four `RuntimeException` throws in `GitHubAppAuth` (linje 75, 83) and `GitHubIssueService` (linje 155, 177) with `GitHubApiException`, preserving cause chains.

Also adds internal `baseUrl`/`apiBaseUrl` constructor params (default `https://api.github.com`) to enable TDD against a local JVM HttpServer without new test dependencies.