### PR TITLE
Test #141: FlywayMigrationIntegrationTest mot ekte PostgreSQL 16 via Testcontainers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,11 @@ dependencies {
 
     // H2 (test — in-memory database for Flyway- og Exposed-tester)
     testImplementation("com.h2database:h2:2.4.240")
+
+    // Testcontainers (integrasjonstester mot ekte PostgreSQL 16)
+    testImplementation("org.testcontainers:postgresql:1.21.0")
+    testImplementation("org.testcontainers:junit-jupiter:1.21.0")
+    testImplementation("org.postgresql:postgresql:42.7.4")
 }
 
 java {
@@ -93,6 +98,8 @@ java {
 
 tasks.test {
     useJUnitPlatform()
+    // Testcontainers shaded docker-java defaults to API 1.32 — override to 1.41 for Docker daemons with min API >= 1.40
+    systemProperty("api.version", "1.41")
 }
 
 publishing {

--- a/src/test/kotlin/no/grunnmur/FlywayMigrationIntegrationTest.kt
+++ b/src/test/kotlin/no/grunnmur/FlywayMigrationIntegrationTest.kt
@@ -1,0 +1,52 @@
+package no.grunnmur
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import javax.sql.DataSource
+
+@Tag("integration")
+@Testcontainers
+class FlywayMigrationIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16")
+    }
+
+    private fun dataSource(): DataSource = PGSimpleDataSource().apply {
+        setUrl(postgres.jdbcUrl)
+        user = postgres.username
+        setPassword(postgres.password)
+    }
+
+    @Test
+    fun `configure returnerer gyldig Flyway-instans mot ekte PostgreSQL`() {
+        val flyway = FlywayMigration.configure(dataSource())
+        assertNotNull(flyway)
+        assertTrue(flyway.configuration.isBaselineOnMigrate)
+        assertTrue(flyway.configuration.isCleanDisabled)
+        assertEquals("0", flyway.configuration.baselineVersion.version)
+    }
+
+    @Test
+    fun `migrate returnerer 0 uten migrasjoner mot ekte PostgreSQL`() {
+        val count = FlywayMigration.migrate(dataSource())
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun `migrate kjoerer PostgreSQL-spesifikk DDL med IDENTITY JSONB og TIMESTAMPTZ`() {
+        val flyway = FlywayMigration.configure(
+            dataSource(),
+            locations = listOf("classpath:db/pg-testmigration")
+        )
+        val result = flyway.migrate()
+        assertEquals(1, result.migrationsExecuted)
+    }
+}

--- a/src/test/resources/db/pg-testmigration/V1__create_pg_test_table.sql
+++ b/src/test/resources/db/pg-testmigration/V1__create_pg_test_table.sql
@@ -1,0 +1,9 @@
+-- PostgreSQL-spesifikk DDL — H2 støtter ikke GENERATED ALWAYS AS IDENTITY, JSONB eller TIMESTAMPTZ
+CREATE TABLE pg_test_table (
+    id         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name       VARCHAR(100)  NOT NULL,
+    metadata   JSONB,
+    created_at TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ON pg_test_table (created_at);


### PR DESCRIPTION
Fixes #141

## Hva ble gjort

- Ny testklasse `FlywayMigrationIntegrationTest` med `@Tag("integration")` og `@Testcontainers` som starter PostgreSQL 16 via Testcontainers og kjører Flyway-migrasjoner mot ekte PostgreSQL
- Ny SQL-fil `db/pg-testmigration/V1__create_pg_test_table.sql` med PostgreSQL-spesifikk DDL (`GENERATED ALWAYS AS IDENTITY`, `JSONB`, `TIMESTAMPTZ`) som H2 ikke støtter
- Testcontainers 1.21.0 + `org.postgresql:postgresql:42.7.4` lagt til som testAvhengigheter
- `systemProperty("api.version", "1.41")` i `tasks.test` for å omgå docker-java defaulting til API 1.32 på Docker-daemon som krever minimum 1.40
- Eksisterende `FlywayMigrationTest.kt` og `V1__create_test_table.sql` (H2) beholdt uendret