### PR TITLE
ci: migrate test-full-skip to self-hosted runner

### DIFF
--- a/.github/workflows/test-full-skip.yml
+++ b/.github/workflows/test-full-skip.yml
@@ -27,6 +27,6 @@ permissions:
 jobs:
   backend:
     name: Backend-tester
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, nuc]
     steps:
       - run: echo "Doc-only PR — bestaatt (ingen testing noedvendig)"


### PR DESCRIPTION
## Summary

- Endrer `runs-on: ubuntu-latest` til `runs-on: [self-hosted, linux, nuc]` i `test-full-skip.yml`
- Passthrough-workflowen for doc-only PRs kjører nå på NUC-runneren i stedet for GitHub-hosted runner

## Test plan

- [ ] Verifiser at workflowen fyrer på en doc-only PR og produserer check-navnet "Backend-tester"
- [ ] Verifiser at auto-merge fungerer som forventet for doc-only PRer etter endringen

🤖 Generated with [Claude Code](https://claude.com/claude-code)