### PR TITLE
security: pin dorny/test-reporter@v3 til SHA (v3.0.0)

### DIFF
--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -52,7 +52,7 @@ jobs:
           name: test-rapport
           path: build/reports/tests/test/
           retention-days: 30
-      - uses: dorny/test-reporter@v3
+      - uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always()
         with:
           name: JUnit Tester


### PR DESCRIPTION
## Summary

Supply-chain hardening: pinner `dorny/test-reporter@v3` (floating tag) til SHA `a43b3a5f...7366` (v3.0.0, 2026-03-21).

Floating v3-tag kan teoretisk overskrives av ondsinnet aktør om dorny-kontoen kompromitteres. Pinning til SHA eliminerer den risikoen.

Closes #149

## Test plan
- [ ] CI grønn — workflow kjører som før med samme funksjonalitet (kun referansen endret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)