### PR TITLE
docs: rydd lo-finans-referanser etter arkivering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # grunnmur
 
 Felles Kotlin-bibliotek for alle Ktor-apper i portefoljen.
-Brukes av lo-finans, biologportal, 6810 og styreportal.
+Brukes av biologportal, 6810 og styreportal.
 
 Sist oppdatert: 2026-05-14
 
@@ -241,8 +241,8 @@ Dataklasser:
 #### GitHubIssueService (`GitHubIssueService.kt`) — class
 GitHub API for issues. Stoetter PAT og GitHub App-autentisering. Saniterer all input via InputSanitizer. **Implementerer Closeable — lukk instansen med `close()` eller try-with-resources.**
 
-- `createIssue(title, senderName, senderEmail, description, consoleLogs?, imageFilenames?, labels): GitHubIssueResponse` (suspend)
-- `updateIssueBody(issueNumber: Int, body: String)` (suspend)
+- `createIssue(title, senderName, senderEmail, description, consoleLogs?, imageFilenames?, labels): GitHubIssueResponse` (suspend) — kaster `GitHubApiException` ved 4xx/5xx fra GitHub
+- `updateIssueBody(issueNumber: Int, body: String)` (suspend) — kaster `GitHubApiException` ved 4xx/5xx fra GitHub
 - `buildBody(senderName, senderEmail, description, consoleLogs?, imageFilenames?): String`
 - `close()` — lukker den interne HttpClient-instansen
 
@@ -251,7 +251,7 @@ Config: `Config(token?, appAuth?, repo, uploadDir?, publicBaseUrl?)`
 #### GitHubAppAuth (`GitHubAppAuth.kt`) — class
 GitHub App JWT (RS256) autentisering med installation token-caching. Leser faktisk `expires_at` fra GitHub API-respons og fornyer automatisk 5 min foer utloep. **Atomisk token-refresh** via Mutex sikrer at kun én coroutine kaller GitHub API selv under parallell load (double-checked locking). **Implementerer Closeable — lukk instansen med `close()` eller try-with-resources.**
 
-- `getToken(): String` (suspend) — returnerer gyldig installation token, cacher basert paa faktisk utløpstid fra API. Thread-safe.
+- `getToken(): String` (suspend) — returnerer gyldig installation token, cacher basert paa faktisk utløpstid fra API. Thread-safe. Kaster `GitHubApiException` ved 4xx/5xx fra GitHub eller parsefeil i `expires_at`.
 - `parseExpiresAt(expiresAt: String): Long` — parser ISO-8601 `expires_at` fra GitHub til millisekunder siden epoch
 - `close()` — lukker den interne HttpClient-instansen
 
@@ -281,12 +281,13 @@ Config: `Config(uploadDir, baseUrl, repo = "", maxFileSize = 2MB, maxImagesPerIs
 
 ### Modeller
 
-#### Exceptions (`Exceptions.kt`) — 5 exception-klasser
+#### Exceptions (`Exceptions.kt`) — 6 exception-klasser
 - `BadRequestException(message)` -> 400
 - `NotFoundException(message)` -> 404
 - `ForbiddenException(message)` -> 403
 - `RateLimitException(message, retryAfterSeconds?)` -> 429 (med `Retry-After`-header naar tilgjengelig)
 - `AuthenticationException(message)` -> 401
+- `GitHubApiException(message, statusCode?, cause?)` — kastes av GitHubAppAuth og GitHubIssueService ved 4xx/5xx-svar fra GitHub eller parsefeil (statusCode = null)
 
 ## Teknisk
 
@@ -389,7 +390,7 @@ Apper sjekker ut grunnmur med `grunnmur-access` GitHub App (App ID `GRUNNMUR_APP
 
 ## Versjonsstrategi
 
-`build.gradle.kts` har `version = "1.0.0"` hardkodet med hensikt. Appene (lo-finans, biologportal, 6810, styreportal) konsumerer grunnmur via Gradle composite build (`includeBuild`) — ikke via Maven-koordinater. Sporbarhet skjer via git commit-hash, ikke versjonsnummer.
+`build.gradle.kts` har `version = "1.0.0"` hardkodet med hensikt. Appene (biologportal, 6810, styreportal) konsumerer grunnmur via Gradle composite build (`includeBuild`) — ikke via Maven-koordinater. Sporbarhet skjer via git commit-hash, ikke versjonsnummer.
 
 `publishing`-blokken i `build.gradle.kts` eksisterer for fremtidig publisering til GitHub Packages, men er ikke i rutinemessig bruk. Versjonen bumpes kun manuelt ved breaking changes — ingen automatisk bump, ingen SNAPSHOT-konvensjon, ingen CHANGELOG.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">Felles Kotlin-bibliotek for Ktor-appene i portefoljen.<br>Standardiserer patterns som tidligere var duplisert med variasjoner mellom apper.</p>
 
-<p align="center"><em>Sist oppdatert: 2026-04-08</em></p>
+<p align="center"><em>Sist oppdatert: 2026-05-14</em></p>
 
 ---
 
@@ -137,7 +137,7 @@ install(StatusPages) {
 }
 ```
 
-Mapper: `BadRequestException` -> 400, `NotFoundException` -> 404, `ForbiddenException` -> 403, `RateLimitException` -> 429, `AuthenticationException` -> 401, `IllegalArgumentException` -> 400, `Throwable` -> 500 (skjuler detaljer i produksjon).
+Mapper: `BadRequestException` -> 400, `NotFoundException` -> 404, `ForbiddenException` -> 403, `RateLimitException` -> 429, `AuthenticationException` -> 401, `GitHubApiException` -> 500 (fra GitHub API-feil), `IllegalArgumentException` -> 400, `Throwable` -> 500 (skjuler detaljer i produksjon).
 
 ---
 
@@ -280,7 +280,7 @@ val result = smtp.send(EmailMessage(
 Dataklasser: **SmtpConfig**, **EmailMessage**, **EmailAttachment**, **SendResult**
 
 #### GitHubIssueService (`GitHubIssueService.kt`)
-Oppretter og oppdaterer GitHub Issues via API. Stoetter baade PAT og GitHub App-autentisering. All input saniteres via InputSanitizer.
+Oppretter og oppdaterer GitHub Issues via API. Stoetter baade PAT og GitHub App-autentisering. All input saniteres via InputSanitizer. Kaster `GitHubApiException` ved API-feil.
 
 ```kotlin
 val service = GitHubIssueService(GitHubIssueService.Config(
@@ -292,21 +292,21 @@ val result = service.createIssue(title = "Bug", senderName = "Ola", senderEmail 
 
 | Funksjon | Signatur | Beskrivelse |
 |----------|----------|-------------|
-| `createIssue` | `(title, senderName, senderEmail, description, ...): GitHubIssueResponse` | Oppretter issue (suspend) |
-| `updateIssueBody` | `(issueNumber: Int, body: String)` | Oppdaterer issue-body (suspend) |
+| `createIssue` | `(title, senderName, senderEmail, description, ...): GitHubIssueResponse` | Oppretter issue (suspend), kaster GitHubApiException |
+| `updateIssueBody` | `(issueNumber: Int, body: String)` | Oppdaterer issue-body (suspend), kaster GitHubApiException |
 | `buildBody` | `(senderName, senderEmail, description, ...): String` | Bygger markdown-body |
 
 #### GitHubAppAuth (`GitHubAppAuth.kt`)
-GitHub App-autentisering med JWT (RS256), automatisk caching av installation tokens og **thread-safe token-refresh** via Mutex (double-checked locking).
+GitHub App-autentisering med JWT (RS256), automatisk caching av installation tokens og **thread-safe token-refresh** via Mutex (double-checked locking). Kaster `GitHubApiException` ved API-feil eller parsefeil.
 
 ```kotlin
 val auth = GitHubAppAuth(appId = "12345", privateKeyPem = pemKey, installationId = "67890")
-val token = auth.getToken() // suspend — cacher og fornyer automatisk, atomisk under parallell last
+val token = auth.getToken() // suspend — cacher og fornyer automatisk, atomisk under parallell last, kaster GitHubApiException
 ```
 
 | Funksjon | Signatur | Beskrivelse |
 |----------|----------|-------------|
-| `getToken` | `(): String` (suspend) | Henter gyldig installation token, thread-safe |
+| `getToken` | `(): String` (suspend) | Henter gyldig installation token, thread-safe, kaster GitHubApiException |
 
 #### GitHubIssueRoutes (`GitHubIssueRoutes.kt`)
 Ktor-ruter for issue-oppretting (multipart med bilder) og GitHub webhook-mottak med HMAC-SHA256-signaturverifisering.
@@ -359,6 +359,7 @@ Typed exceptions som mappes til HTTP-statuskoder via StatusPages:
 | `ForbiddenException` | 403 Forbidden |
 | `RateLimitException` | 429 Too Many Requests |
 | `AuthenticationException` | 401 Unauthorized |
+| `GitHubApiException` | 500 Internal Server Error (fra GitHub API-feil) |
 
 #### TotpModels (`TotpModels.kt`)
 Serialiserbare dataklasser for TOTP-operasjoner:
@@ -410,7 +411,6 @@ services:
 
 ## Brukes av
 
-- [lo-finans](https://github.com/TommySkogstad/lo-finans)
 - [biologportal](https://github.com/TommySkogstad/biologportal)
 - [6810](https://github.com/TommySkogstad/6810)
 - [styreportal](https://github.com/TommySkogstad/styreportal)


### PR DESCRIPTION
## Sammendrag

lo-finans-prosjektet arkivert 2026-05-19. Rydder historiske doc-referanser i dette repoet.

Endringene er rent dokumentariske og påvirker ikke kjøretid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)