### PR TITLE
Fix #169: Update dependency versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,8 +412,8 @@ services:
 
 - Kotlin 2.3.21, Ktor 3.5.0 (Server + Client CIO), Exposed 1.3.0, JVM 25
 - kotlinx-serialization-json 1.11.0, Jakarta Mail 2.1.5, Flyway 11.19.1
-- kotlin-onetimepassword 2.4.1, SLF4J 2.0.17
-- Testcontainers 1.21.0, PostgreSQL JDBC 42.7.4 (integrasjonstester)
+- kotlin-onetimepassword 2.4.1, SLF4J 2.0.18
+- Testcontainers 1.21.4, PostgreSQL JDBC 42.7.11 (integrasjonstester)
 - Alle avhengigheter er `compileOnly` — apper bruker sine egne versjoner
 - Versjoner MA holdes i sync med appene (binaer inkompatibilitet)
 


### PR DESCRIPTION
Fixes #169

## Changes
- SLF4J: 2.0.17 → 2.0.18
- Testcontainers: 1.21.0 → 1.21.4
- PostgreSQL JDBC: 42.7.4 → 42.7.11

Syncs README with actual versions in build.gradle.kts.