### PR TITLE
docs: legg til smart-casual, maskemester og vinforalle i konsumentapp-lister

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # grunnmur
 
 Felles Kotlin-bibliotek for alle Ktor-apper i portefoljen.
-Brukes av biologportal, 6810 og styreportal.
+Brukes av biologportal, 6810, styreportal, smart-casual, maskemester og vinforalle.
 
 Sist oppdatert: 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -424,3 +424,6 @@ services:
 - [biologportal](https://github.com/TommySkogstad/biologportal)
 - [6810](https://github.com/TommySkogstad/6810)
 - [styreportal](https://github.com/TommySkogstad/styreportal)
+- [smart-casual](https://github.com/TommySkogstad/smart-casual)
+- [maskemester](https://github.com/TommySkogstad/maskemester)
+- [vinforalle](https://github.com/TommySkogstad/vinforalle)


### PR DESCRIPTION
Fixes #171