### PR TITLE
ci: pin GitHub Actions til SHA — grunnmur-backend

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.GRUNNMUR_APP_ID }}
           private-key: ${{ secrets.GRUNNMUR_APP_KEY }}

--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -39,14 +39,14 @@ jobs:
     runs-on: [self-hosted, linux, nuc]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Kjør alle backend-tester
         run: ./gradlew test --no-daemon
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-rapport

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
     runs-on: [self-hosted, linux, nuc]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '25'
           distribution: 'temurin'


### PR DESCRIPTION
Pinner alle `uses:`-referanser til full commit SHA med `pinact v4`.

Funksjonelt identisk (samme tag, bare eksplisitt SHA).

Fixes #185

Del av TommySkogstad/misc-scripts#846.