### PR TITLE
Fix #190: remove outdated 'Sist oppdatert' date from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 <p align="center">Felles Kotlin-bibliotek for Ktor-appene i portefoljen.<br>Standardiserer patterns som tidligere var duplisert med variasjoner mellom apper.</p>
 
-<p align="center"><em>Sist oppdatert: 2026-05-14</em></p>
-
 ---
 
 ## Moduloversikt


### PR DESCRIPTION
Fixes #190

Removes the manually-updated 'Sist oppdatert: 2026-05-14' field from the README. Using git history as the source of truth for when documentation was last modified prevents this from becoming outdated again.