### PR TITLE
Fix #195: legg til salt-parameter i OtpUtils.hashCode() og verify()

### DIFF
--- a/src/main/kotlin/no/grunnmur/OtpUtils.kt
+++ b/src/main/kotlin/no/grunnmur/OtpUtils.kt
@@ -34,9 +34,14 @@ object OtpUtils {
      * Returnerer 64 hex-tegn (lowercase).
      *
      * OTP-koder skal alltid lagres som hash, aldri i klartekst.
+     *
+     * @param salt App-spesifikk hemmelighet (f.eks. OTP_SALT fra .env) som beskytter mot
+     *             forhåndsberegnede regnbuetabeller. Tom streng gir bakoverkompatibel oppførsel
+     *             (usaltet), men bør unngås i nye installasjoner.
      */
-    fun hashCode(code: String): String {
-        val bytes = MessageDigest.getInstance("SHA-256").digest(code.toByteArray(Charsets.UTF_8))
+    fun hashCode(code: String, salt: String = ""): String {
+        val input = if (salt.isEmpty()) code else "$salt:$code"
+        val bytes = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
         return bytes.joinToString("") { "%02x".format(it) }
     }
 
@@ -58,7 +63,8 @@ object OtpUtils {
         expiresAt: LocalDateTime,
         attempts: Int,
         maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
-        devMode: Boolean = false
+        devMode: Boolean = false,
+        salt: String = ""
     ): OtpVerificationResult {
         if (attempts >= maxAttempts) {
             return OtpVerificationResult.TooManyAttempts
@@ -72,7 +78,7 @@ object OtpUtils {
             return OtpVerificationResult.Success
         }
 
-        return if (hashCode(code) == storedHash) {
+        return if (hashCode(code, salt) == storedHash) {
             OtpVerificationResult.Success
         } else {
             OtpVerificationResult.InvalidCode

--- a/src/test/kotlin/no/grunnmur/OtpUtilsTest.kt
+++ b/src/test/kotlin/no/grunnmur/OtpUtilsTest.kt
@@ -61,6 +61,38 @@ class OtpUtilsTest {
             val hash = OtpUtils.hashCode(code)
             assertNotEquals(code, hash)
         }
+
+        @Test
+        fun `salt gir annen hash enn uten salt`() {
+            val code = "123456"
+            val hashUtenSalt = OtpUtils.hashCode(code)
+            val hashMedSalt = OtpUtils.hashCode(code, "app-salt-secret")
+            assertNotEquals(hashUtenSalt, hashMedSalt)
+        }
+
+        @Test
+        fun `forskjellige salter gir forskjellige hasher for samme kode`() {
+            val code = "123456"
+            val hash1 = OtpUtils.hashCode(code, "salt-A")
+            val hash2 = OtpUtils.hashCode(code, "salt-B")
+            assertNotEquals(hash1, hash2)
+        }
+
+        @Test
+        fun `salt og kode med delimiter er entydig`() {
+            // "a:bc" + kode != "a" + ":bc" + kode — delimiter skiller salt fra kode
+            val hash1 = OtpUtils.hashCode("456789", "ab")
+            val hash2 = OtpUtils.hashCode("56789", "ab4")
+            assertNotEquals(hash1, hash2, "salt-kode-grense skal ikke ambigeres")
+        }
+
+        @Test
+        fun `tom salt er bakoverkompatibel`() {
+            val code = "123456"
+            val hashDefault = OtpUtils.hashCode(code)
+            val hashTomSalt = OtpUtils.hashCode(code, "")
+            assertEquals(hashDefault, hashTomSalt, "tom salt skal gi samme hash som ingen salt")
+        }
     }
 
     @Nested
@@ -73,6 +105,27 @@ class OtpUtilsTest {
 
             val result = OtpUtils.verify(code, storedHash, expiry, attempts = 0)
             assertTrue(result is OtpVerificationResult.Success)
+        }
+
+        @Test
+        fun `gyldig kode med salt returnerer Success`() {
+            val code = "123456"
+            val salt = "app-spesifikk-salt"
+            val storedHash = OtpUtils.hashCode(code, salt)
+            val expiry = TimeUtils.nowOslo().plusMinutes(5)
+
+            val result = OtpUtils.verify(code, storedHash, expiry, attempts = 0, salt = salt)
+            assertTrue(result is OtpVerificationResult.Success)
+        }
+
+        @Test
+        fun `feil salt returnerer InvalidCode`() {
+            val code = "123456"
+            val storedHash = OtpUtils.hashCode(code, "riktig-salt")
+            val expiry = TimeUtils.nowOslo().plusMinutes(5)
+
+            val result = OtpUtils.verify(code, storedHash, expiry, attempts = 0, salt = "feil-salt")
+            assertTrue(result is OtpVerificationResult.InvalidCode)
         }
 
         @Test
@@ -154,6 +207,16 @@ class OtpUtilsTest {
 
             val result = OtpUtils.verify("123456", storedHash, expiry, attempts = 3, devMode = true)
             assertTrue(result is OtpVerificationResult.TooManyAttempts)
+        }
+
+        @Test
+        fun `dev-kode fungerer uavhengig av salt`() {
+            // devMode-grenen sjekker klartekst, ikke hash — salt skal ikke påvirke dev-koden
+            val storedHash = OtpUtils.hashCode("999888", "app-salt")
+            val expiry = TimeUtils.nowOslo().plusMinutes(5)
+
+            val result = OtpUtils.verify("123456", storedHash, expiry, attempts = 0, devMode = true, salt = "app-salt")
+            assertTrue(result is OtpVerificationResult.Success)
         }
     }
 }


### PR DESCRIPTION
Fixes #195

## Endringer

-  — nytt valgfritt salt-parameter
-  — sender salt videre til hashCode()
- Salt prependereres med kolon-delimiter (`"$salt:$code"`) for å unngå tvetydighet mellom salt og kode
- Tom salt (default) bevarer bakoverkompatibel oppførsel for eksisterende lagrede hasher

## Tester lagt til

- Salt gir annen hash enn uten salt
- Forskjellige salter gir forskjellige hasher for samme kode
- Kolon-delimiter er entydig (salt+kode-grense kan ikke ambigeres)
- Tom salt er bakoverkompatibel med eksisterende hasher
- verify() med riktig salt → Success
- verify() med feil salt → InvalidCode
- devMode fungerer uavhengig av salt