### PR TITLE
Fix #197: enforce MAX_LIMIT on AuditLogService.findAll()

### DIFF
--- a/src/main/kotlin/no/grunnmur/AuditLogService.kt
+++ b/src/main/kotlin/no/grunnmur/AuditLogService.kt
@@ -23,6 +23,10 @@ import org.slf4j.LoggerFactory
 class AuditLogService {
     private val log = LoggerFactory.getLogger(AuditLogService::class.java)
 
+    companion object {
+        const val MAX_LIMIT = 1000
+    }
+
     /**
      * Logger en handling til revisjonsloggen.
      * Feil i logging stopper ikke hovedoperasjonen.
@@ -66,12 +70,13 @@ class AuditLogService {
         limit: Int = 100,
         offset: Long = 0
     ): List<AuditLogEntry> {
+        val effectiveLimit = limit.coerceIn(1, MAX_LIMIT)
         return transaction {
             val query = AuditLogs.selectAll()
             applyFilters(query, action, entityType, userId, startDate, endDate)
             query
                 .orderBy(AuditLogs.createdAt, SortOrder.DESC)
-                .limit(limit).offset(offset)
+                .limit(effectiveLimit).offset(offset)
                 .map { it.toAuditLogEntry() }
         }
     }

--- a/src/test/kotlin/no/grunnmur/AuditLogServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/AuditLogServiceTest.kt
@@ -156,6 +156,16 @@ class AuditLogServiceTest {
         }
 
         @Test
+        fun `findAll begrenser til MAX_LIMIT naar limit er Int MAX VALUE`() {
+            repeat(10) { i ->
+                service.log(userId = i, action = "A", entityType = "T")
+            }
+
+            val result = service.findAll(limit = Int.MAX_VALUE)
+            assertTrue(result.size <= AuditLogService.MAX_LIMIT, "Forventet maks ${AuditLogService.MAX_LIMIT} rader, fikk ${result.size}")
+        }
+
+        @Test
         fun `findAll respekterer offset`() {
             val now = TimeUtils.nowOslo()
             insertWithCreatedAt(1, "FIRST", "T", now.minusMinutes(2))


### PR DESCRIPTION
Fixes #197