### PR TITLE
Fix #198: SmtpClient implementerer Closeable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,10 +226,11 @@ Felt: `OSLO_ZONE: ZoneId`, `isoDateTime: DateTimeFormatter`, `isoDate: DateTimeF
 ### Tjenester
 
 #### SmtpClient (`SmtpClient.kt`) — class
-Jakarta Mail SMTP-klient. Stoetter plain text + HTML (multipart/alternative), vedlegg (multipart/mixed), traad-kobling (Message-ID/In-Reply-To/References), rate limiting mellom sendinger, dev-modus (logger i stedet for aa sende). **SMTP Session er cached og gjenbrukt** (ikke opprettet paa nytt per sending). STARTTLS og requireAuth er uavhengige — kan konfigureres separat.
+Jakarta Mail SMTP-klient. Stoetter plain text + HTML (multipart/alternative), vedlegg (multipart/mixed), traad-kobling (Message-ID/In-Reply-To/References), rate limiting mellom sendinger, dev-modus (logger i stedet for aa sende). **SMTP Session er cached og gjenbrukt** (ikke opprettet paa nytt per sending). STARTTLS og requireAuth er uavhengige — kan konfigureres separat. **Implementerer Closeable** — kan brukes i `use`-blokker eller lukkes eksplisitt med `close()`.
 
 - `send(message: EmailMessage, forceDelivery: Boolean = false): SendResult`
 - `sendWithMessageId(message: EmailMessage, messageId: String, forceDelivery: Boolean = false): SendResult`
+- `close()` — lukker klienten (Jakarta Mail Session holder ingen langlivde ressurser, men `close()` finnes for konsistens med `GitHubIssueService` og `GitHubAppAuth`)
 
 **SmtpConfig companion function:**
 - `SmtpConfig.fromEnv(getEnv: (String) -> String? = System::getenv): SmtpConfig` — leser config fra miljøvariabler (SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD, SMTP_FROM, SMTP_FROM_NAME, SMTP_REQUIRE_AUTH, SMTP_STARTTLS, SMTP_DEV_MODE, SMTP_TIMEOUT_MS, SMTP_MIN_INTERVAL_MS). Numeriske felt (SMTP_PORT, SMTP_TIMEOUT_MS, SMTP_MIN_INTERVAL_MS) valideres med `toIntOrNull()`/`toLongOrNull()` og gir beskrivende feilmeldinger ved ugyldig input. SMTP_STARTTLS kan settes uavhengig av SMTP_REQUIRE_AUTH for å håndtere self-signed sertifikater på Postfix.

--- a/src/main/kotlin/no/grunnmur/SmtpClient.kt
+++ b/src/main/kotlin/no/grunnmur/SmtpClient.kt
@@ -156,7 +156,7 @@ data class SendResult(
 class SmtpClient(
     private val config: SmtpConfig,
     private val transportAction: ((MimeMessage) -> Unit)? = null
-) {
+) : java.io.Closeable {
     private val logger = LoggerFactory.getLogger(SmtpClient::class.java)
     private val sendLock = Mutex()
 
@@ -193,6 +193,10 @@ class SmtpClient(
         forceDelivery: Boolean = false
     ): SendResult {
         return doSend(message, forceDelivery, customMessageId = messageId)
+    }
+
+    override fun close() {
+        // Jakarta Mail Session holder ingen langlivde ressurser — close() finnes for konsistens med Closeable-kontrakten
     }
 
     private suspend fun doSend(

--- a/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
+++ b/src/test/kotlin/no/grunnmur/SmtpClientTest.kt
@@ -495,6 +495,30 @@ class SmtpClientTest {
     }
 
     @Nested
+    inner class CloseableKontract {
+
+        @Test
+        fun `SmtpClient implementerer Closeable`() {
+            val client: Any = SmtpClient(testConfig) { }
+            assertTrue(client is java.io.Closeable, "SmtpClient skal implementere Closeable")
+        }
+
+        @Test
+        fun `close kaster ikke`() {
+            val client = SmtpClient(testConfig) { }
+            client.close()
+        }
+
+        @Test
+        fun `SmtpClient kan brukes i use-blokk`() = runBlocking {
+            SmtpClient(testConfig) { }.use { client ->
+                val result = client.send(EmailMessage(to = "a@example.com", subject = "use-test", body = "test"))
+                assertTrue(result.success)
+            }
+        }
+    }
+
+    @Nested
     inner class Konfigurasjon {
 
         @Test


### PR DESCRIPTION
Fixes #198

Legger til `Closeable`-implementasjon på `SmtpClient` for konsistens med `GitHubIssueService` og `GitHubAppAuth`.