### PR TITLE
Fix #209: avvis single-label e-postdomener

### DIFF
--- a/src/main/kotlin/no/grunnmur/Validators.kt
+++ b/src/main/kotlin/no/grunnmur/Validators.kt
@@ -21,7 +21,7 @@ object Validators {
 
     // E-post regex (RFC 5322 forenklet)
     private val EMAIL_REGEX = Regex(
-        "^[a-zA-Z0-9.!#\$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\$"
+        "^[a-zA-Z0-9.!#\$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+\$"
     )
 
     // URL regex

--- a/src/test/kotlin/no/grunnmur/ValidatorsTest.kt
+++ b/src/test/kotlin/no/grunnmur/ValidatorsTest.kt
@@ -36,6 +36,14 @@ class ValidatorsTest {
             assertFalse(Validators.isValidEmail("ugyldig"))
             assertFalse(Validators.isValidEmail(""))
         }
+
+        @Test
+        fun `single-label domener avvises`() {
+            assertFalse(Validators.validateEmail("a@b").isValid)
+            assertFalse(Validators.validateEmail("user@localhost").isValid)
+            assertFalse(Validators.isValidEmail("a@b"))
+            assertFalse(Validators.isValidEmail("user@localhost"))
+        }
     }
 
     @Nested


### PR DESCRIPTION
Fixes #209

Endrer `EMAIL_REGEX`-kvantor fra `*` til `+` for domene-suffikset slik at adresser uten punktum i domenet (f.eks. `user@localhost`, `a@b`) avvises.