### PR TITLE
Fix #213: Rett TOTP-vindu-kommentar til ±60s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ AES-256-GCM-kryptering. Nokler: 64 hex-tegn (32 bytes). Output: Base64(IV || cip
 - `base64KeyToHex(base64Key: String): String` — for migrering
 
 #### TotpService (`TotpService.kt`) — object
-TOTP tofaktorautentisering (RFC 6238). SHA1, 30s steg, 6 siffer, +-2 vinduer toleranse. Bruker EncryptionUtils for kryptering. Dev-kode: "123456".
+TOTP tofaktorautentisering (RFC 6238). SHA1, 30s steg, 6 siffer, ±2 vinduer = ±60 sekunder. Bruker EncryptionUtils for kryptering. Dev-kode: "123456".
 
 - `setupTotp(encryptionKey: String, issuer: String, accountName: String): TotpSetupResult` — genererer hemmelighet + QR-URI
 - `confirmTotp(encryptedSecret: String, encryptionKey: String, code: String): Boolean`

--- a/src/main/kotlin/no/grunnmur/TotpService.kt
+++ b/src/main/kotlin/no/grunnmur/TotpService.kt
@@ -22,7 +22,7 @@ object TotpService {
     private const val DEV_TOTP_CODE = "123456"
     private const val TIME_STEP_SECONDS = 30
     private const val CODE_DIGITS = 6
-    private const val WINDOW_SIZE = 2 // ±2 vinduer (2 min toleranse)
+    private const val WINDOW_SIZE = 2 // ±2 vinduer = ±60 sekunder
 
     /**
      * Starter TOTP-oppsett — genererer hemmelighet og returnerer kryptert secret + QR-URI.


### PR DESCRIPTION
Fixes #213

Retter villedende kommentar «2 min toleranse» til presist «±60 sekunder» i TotpService.kt og CLAUDE.md. `WINDOW_SIZE = 2` betyr ±2 steg × 30s = ±60 sekunder, ikke «2 min» (som antyder ±2 min).

Ren dokumentasjonsendring — ingen adferdsendring.