### PR TITLE
Fix #211: KeyRateLimiter interface for GitHubIssueRoutesConfig

### DIFF
--- a/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
@@ -19,7 +19,7 @@ import javax.crypto.spec.SecretKeySpec
 data class GitHubIssueRoutesConfig(
     val issueService: GitHubIssueService,
     val imageService: ImageUploadService?,
-    val rateLimiter: RateLimiter,
+    val rateLimiter: KeyRateLimiter,
     val webhookSecret: String
 )
 

--- a/src/main/kotlin/no/grunnmur/RateLimitPresets.kt
+++ b/src/main/kotlin/no/grunnmur/RateLimitPresets.kt
@@ -17,7 +17,7 @@ import java.security.MessageDigest
  * }
  * ```
  */
-class CompositeRateLimiter(private vararg val limiters: RateLimiter) {
+class CompositeRateLimiter(private vararg val limiters: RateLimiter) : KeyRateLimiter {
 
     init {
         require(limiters.isNotEmpty()) { "CompositeRateLimiter krever minst én limiter" }
@@ -33,7 +33,7 @@ class CompositeRateLimiter(private vararg val limiters: RateLimiter) {
      * per-minutt-kall per-time-kvoten fullstendig. Vurder stoerrelsen paa
      * per-time-presets for scenarioer der mange brukere deler IP (CGNAT, kontor).
      */
-    fun isAllowed(key: String): Boolean {
+    override fun isAllowed(key: String): Boolean {
         var allowed = true
         for (limiter in limiters) {
             if (!limiter.isAllowed(key)) {
@@ -61,7 +61,7 @@ class CompositeRateLimiter(private vararg val limiters: RateLimiter) {
      * Returnerer maksimum retry-after-tid paa tvers av alle limitere.
      * Returnerer null hvis ingen limiter er blokkert.
      */
-    fun retryAfterSeconds(key: String): Long? {
+    override fun retryAfterSeconds(key: String): Long? {
         return limiters.mapNotNull { it.retryAfterSeconds(key) }.maxOrNull()
     }
 }

--- a/src/main/kotlin/no/grunnmur/RateLimiter.kt
+++ b/src/main/kotlin/no/grunnmur/RateLimiter.kt
@@ -3,6 +3,16 @@ package no.grunnmur
 import java.util.concurrent.ConcurrentHashMap
 
 /**
+ * Felles interface for enkle nøkkel-baserte rate limitere.
+ * Implementeres av [RateLimiter] og [CompositeRateLimiter].
+ * [AuthRateLimiter] er holdt utenfor da den bruker to nøkler (ip + identifikator).
+ */
+interface KeyRateLimiter {
+    fun isAllowed(key: String): Boolean
+    fun retryAfterSeconds(key: String): Long?
+}
+
+/**
  * In-memory rate limiter med sliding window og automatisk cleanup.
  *
  * Bruk:
@@ -23,7 +33,7 @@ class RateLimiter(
     private val maxAttempts: Int = 5,
     val windowMs: Long = 300_000,
     private val maxEntries: Int = 10_000
-) {
+) : KeyRateLimiter {
     private data class AttemptRecord(val count: Int, val windowStart: Long)
 
     private val attempts = ConcurrentHashMap<String, AttemptRecord>()
@@ -34,7 +44,7 @@ class RateLimiter(
      * Sjekker om en noekkel er tillatt og registrerer forsoekets.
      * Returnerer true hvis tillatt, false hvis blokkert.
      */
-    fun isAllowed(key: String): Boolean {
+    override fun isAllowed(key: String): Boolean {
         val now = System.currentTimeMillis()
         cleanup(now)
 
@@ -84,7 +94,7 @@ class RateLimiter(
      * Returnerer antall sekunder til vinduet utloeper for en blokkert noekkel.
      * Returnerer null hvis noekkel ikke er blokkert.
      */
-    fun retryAfterSeconds(key: String): Long? {
+    override fun retryAfterSeconds(key: String): Long? {
         val now = System.currentTimeMillis()
         val record = attempts[key] ?: return null
 

--- a/src/test/kotlin/no/grunnmur/GitHubIssueRoutesTest.kt
+++ b/src/test/kotlin/no/grunnmur/GitHubIssueRoutesTest.kt
@@ -91,6 +91,28 @@ class GitHubIssueRoutesTest {
     }
 
     @Nested
+    inner class KeyRateLimiterInterface {
+
+        @Test
+        fun `GitHubIssueRoutesConfig tar imot CompositeRateLimiter som rateLimiter`() {
+            val compositeLimiter = CompositeRateLimiter(
+                RateLimiter(maxAttempts = 5, windowMs = 60_000),
+                RateLimiter(maxAttempts = 10, windowMs = 3_600_000)
+            )
+            val fakeService = GitHubIssueService(
+                GitHubIssueService.Config(token = "fake-token", repo = "fake/fake")
+            )
+            val config = GitHubIssueRoutesConfig(
+                issueService = fakeService,
+                imageService = null,
+                rateLimiter = compositeLimiter,
+                webhookSecret = "test-secret"
+            )
+            assertTrue(config.rateLimiter.isAllowed("127.0.0.1"))
+        }
+    }
+
+    @Nested
     inner class PostIssueValidation {
 
         private fun ApplicationTestBuilder.setupApp() {


### PR DESCRIPTION
Fixes #211

Introduces  interface so  can accept both  and .

- Added  in 
-  and  now implement 
-  changed from  to 
-  (two-key signature) left outside the interface
- Existing callers constructing  have no source-compatibility break