### PR TITLE
Fix: AuditLogService.log() — flytt try/catch inni withContext

### DIFF
--- a/src/main/kotlin/no/grunnmur/AuditLogService.kt
+++ b/src/main/kotlin/no/grunnmur/AuditLogService.kt
@@ -42,8 +42,8 @@ class AuditLogService {
         details: String? = null,
         ipAddress: String? = null
     ) {
-        try {
-            withContext(Dispatchers.IO) {
+        withContext(Dispatchers.IO) {
+            try {
                 transaction {
                     AuditLogs.insert {
                         it[AuditLogs.userId] = userId
@@ -56,9 +56,9 @@ class AuditLogService {
                         it[AuditLogs.createdAt] = TimeUtils.nowOslo()
                     }
                 }
+            } catch (e: Exception) {
+                log.error("Kunne ikke logge handling: ${e.message}", e)
             }
-        } catch (e: Exception) {
-            log.error("Kunne ikke logge handling: ${e.message}", e)
         }
     }
 

--- a/src/test/kotlin/no/grunnmur/AuditLogServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/AuditLogServiceTest.kt
@@ -120,9 +120,7 @@ class AuditLogServiceTest {
             transaction(database) {
                 SchemaUtils.drop(AuditLogs)
             }
-            assertDoesNotThrow {
-                runBlocking { service.log(userId = 1, action = "CREATE", entityType = "USER") }
-            }
+            service.log(userId = 1, action = "CREATE", entityType = "USER")
         }
     }
 


### PR DESCRIPTION
Oppfølging til #229 (closes #225 via PR #229 allerede).

Fikser bug identifisert av QA:  utenfor  ville swallet  og brutt kooperativ kanselleringssemantikk. Bringer -blokken inni  slik at kun transaksjons-exceptions fanges.

Fjerner også redundant nestet  i test.