### PR TITLE
Fix #227: separat rate limiter for bildeopplasting i GitHubIssueRoutes

### DIFF
--- a/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
+++ b/src/main/kotlin/no/grunnmur/GitHubIssueRoutes.kt
@@ -15,12 +15,18 @@ import javax.crypto.spec.SecretKeySpec
 
 /**
  * Konfigurasjon for issue-ruter.
+ *
+ * [imageRateLimiter] begrenser totalt antall bilder lastet opp per IP på tvers av
+ * forespørsler (f.eks. `imageUploadRateLimiter()` = 12/time). Null = ingen separat kvote.
+ * [maxImagesPerRequest] avviser forespørsler med for mange bilder med 400.
  */
 data class GitHubIssueRoutesConfig(
     val issueService: GitHubIssueService,
     val imageService: ImageUploadService?,
     val rateLimiter: KeyRateLimiter,
-    val webhookSecret: String
+    val webhookSecret: String,
+    val imageRateLimiter: KeyRateLimiter? = null,
+    val maxImagesPerRequest: Int = 3
 )
 
 @Serializable
@@ -90,6 +96,7 @@ fun Route.gitHubIssueRoutes(config: GitHubIssueRoutesConfig) {
         var consoleLogs: String? = null
         var labels = emptyList<String>()
         val imageData = mutableListOf<Pair<ByteArray, String>>()
+        var imageCountSeen = 0
 
         multipart.forEachPart { part ->
             when (part) {
@@ -105,14 +112,21 @@ fun Route.gitHubIssueRoutes(config: GitHubIssueRoutesConfig) {
                 }
                 is PartData.FileItem -> {
                     if (part.name == "images") {
-                        val bytes = part.provider().toByteArray()
-                        val filename = part.originalFileName ?: "image"
-                        imageData.add(bytes to filename)
+                        imageCountSeen++
+                        if (imageCountSeen <= config.maxImagesPerRequest) {
+                            val bytes = part.provider().toByteArray()
+                            val filename = part.originalFileName ?: "image"
+                            imageData.add(bytes to filename)
+                        }
                     }
                 }
                 else -> {}
             }
             part.dispose()
+        }
+
+        if (imageCountSeen > config.maxImagesPerRequest) {
+            throw BadRequestException("For mange bilder (maks ${config.maxImagesPerRequest} per forespoersel)")
         }
 
         if (title.isBlank()) throw BadRequestException("Tittel er paakrevd")
@@ -135,6 +149,10 @@ fun Route.gitHubIssueRoutes(config: GitHubIssueRoutesConfig) {
         val imageUrls = mutableListOf<String>()
         if (config.imageService != null && imageData.isNotEmpty()) {
             for ((bytes, filename) in imageData) {
+                if (config.imageRateLimiter != null && !config.imageRateLimiter.isAllowed(clientIp)) {
+                    call.application.log.warn("Bildekvote oppbrukt for IP $clientIp ved issue #${issueResponse.number}")
+                    break
+                }
                 val result = config.imageService.uploadImage(issueResponse.number, bytes, filename)
                 result.onSuccess { url -> imageUrls.add(url) }
                 result.onFailure { e ->

--- a/src/main/kotlin/no/grunnmur/RateLimitPresets.kt
+++ b/src/main/kotlin/no/grunnmur/RateLimitPresets.kt
@@ -135,6 +135,24 @@ fun apiRateLimiterAnonymous(
 ): RateLimiter = RateLimiter(maxAttempts = maxRequests, windowMs = windowMs)
 
 /**
+ * Ferdigkonfigurert rate limiter for bildeopplasting per IP.
+ * Teller bilder (ikke forespørsler). Standard: 12 bilder/time per IP —
+ * tilsvarer 4 fulle issue-opplastinger à 3 bilder.
+ *
+ * Bruk i GitHubIssueRoutesConfig:
+ * ```
+ * GitHubIssueRoutesConfig(
+ *     ...,
+ *     imageRateLimiter = imageUploadRateLimiter()
+ * )
+ * ```
+ */
+fun imageUploadRateLimiter(
+    maxImages: Int = 12,
+    windowMs: Long = 3_600_000
+): RateLimiter = RateLimiter(maxAttempts = maxImages, windowMs = windowMs)
+
+/**
  * Rate limiter som kombinerer IP-basert og identifikator-basert limiting.
  * Begge sjekkes alltid — den strengeste vinner (begge maa tillate).
  * Identifikatorer (telefonnummer/e-post) hashes med SHA-256 saa de ikke lagres i klartekst.

--- a/src/test/kotlin/no/grunnmur/GitHubIssueRoutesTest.kt
+++ b/src/test/kotlin/no/grunnmur/GitHubIssueRoutesTest.kt
@@ -12,6 +12,8 @@ import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import java.net.InetSocketAddress
+import java.nio.file.Files
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import javax.crypto.Mac
@@ -196,6 +198,165 @@ class GitHubIssueRoutesTest {
                 }
             } finally {
                 server.stop(0)
+            }
+        }
+    }
+
+    @Nested
+    inner class ImageRateLimit {
+
+        private fun pngBytes(size: Int = 100): ByteArray {
+            val header = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+            return header + ByteArray(size - header.size)
+        }
+
+        private fun imagePart(index: Int, bytes: ByteArray) = FormPart(
+            "images", bytes, Headers.build {
+                append(HttpHeaders.ContentDisposition, "form-data; name=\"images\"; filename=\"img$index.png\"")
+                append(HttpHeaders.ContentType, "image/png")
+            }
+        )
+
+        private fun createGitHubServer(issueNumber: Int = 42): HttpServer {
+            val server = HttpServer.create(InetSocketAddress(0), 0)
+            server.createContext("/repos/fake/fake/issues") { exchange ->
+                exchange.requestBody.use { it.readBytes() }
+                val body = """{"number":$issueNumber,"html_url":"https://github.com/fake/fake/issues/$issueNumber"}""".toByteArray()
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                val status = if (exchange.requestMethod == "POST") 201 else 200
+                exchange.sendResponseHeaders(status, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+            return server
+        }
+
+        @Test
+        fun `for mange bilder gir 400`() = testApplication {
+            val fakeService = GitHubIssueService(
+                GitHubIssueService.Config(token = "fake-token", repo = "fake/fake")
+            )
+            application {
+                install(ContentNegotiation) { json() }
+                install(StatusPages) { grunnmurExceptionHandlers() }
+                routing {
+                    gitHubIssueRoutes(GitHubIssueRoutesConfig(
+                        issueService = fakeService,
+                        imageService = null,
+                        rateLimiter = RateLimiter(maxAttempts = 100, windowMs = 60_000),
+                        webhookSecret = "test-secret",
+                        maxImagesPerRequest = 2
+                    ))
+                }
+            }
+            val response = client.post("/api/issues") {
+                setBody(MultiPartFormDataContent(formData {
+                    append("title", "Test")
+                    append("senderName", "Test Bruker")
+                    append("senderEmail", "test@example.com")
+                    append("description", "Beskrivelse")
+                    repeat(3) { append(imagePart(it, pngBytes())) }
+                }))
+            }
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+        @Test
+        fun `imageRateLimiter stopper bildeopplasting naar kvoten er oppbrukt`() {
+            val uploadDir = Files.createTempDirectory("grunnmur-test-uploads")
+            val server = createGitHubServer(issueNumber = 42)
+            try {
+                testApplication {
+                    val fakeService = GitHubIssueService(
+                        GitHubIssueService.Config(token = "fake-token", repo = "fake/fake"),
+                        "http://localhost:${server.address.port}"
+                    )
+                    val imageService = ImageUploadService(
+                        ImageUploadService.Config(
+                            uploadDir = uploadDir.toString(),
+                            baseUrl = "https://example.com/uploads",
+                            repo = "fake/fake"
+                        )
+                    )
+                    application {
+                        install(ContentNegotiation) { json() }
+                        install(StatusPages) { grunnmurExceptionHandlers() }
+                        routing {
+                            gitHubIssueRoutes(GitHubIssueRoutesConfig(
+                                issueService = fakeService,
+                                imageService = imageService,
+                                rateLimiter = RateLimiter(maxAttempts = 100, windowMs = 60_000),
+                                webhookSecret = "test-secret",
+                                imageRateLimiter = RateLimiter(maxAttempts = 1, windowMs = 60_000)
+                            ))
+                        }
+                    }
+                    val response = client.post("/api/issues") {
+                        setBody(MultiPartFormDataContent(formData {
+                            append("title", "Test")
+                            append("senderName", "Test Bruker")
+                            append("senderEmail", "test@example.com")
+                            append("description", "Beskrivelse")
+                            repeat(2) { append(imagePart(it, pngBytes())) }
+                        }))
+                    }
+                    assertEquals(HttpStatusCode.Created, response.status)
+                    val parsed = Json { ignoreUnknownKeys = true }
+                        .decodeFromString<CreateIssueResponse>(response.bodyAsText())
+                    assertEquals(1, parsed.imageUrls.size, "imageRateLimiter (1/min) skal stoppe etter 1 bilde")
+                }
+            } finally {
+                server.stop(0)
+                uploadDir.toFile().deleteRecursively()
+            }
+        }
+
+        @Test
+        fun `uten imageRateLimiter lastes alle bilder opp`() {
+            val uploadDir = Files.createTempDirectory("grunnmur-test-uploads")
+            val server = createGitHubServer(issueNumber = 99)
+            try {
+                testApplication {
+                    val fakeService = GitHubIssueService(
+                        GitHubIssueService.Config(token = "fake-token", repo = "fake/fake"),
+                        "http://localhost:${server.address.port}"
+                    )
+                    val imageService = ImageUploadService(
+                        ImageUploadService.Config(
+                            uploadDir = uploadDir.toString(),
+                            baseUrl = "https://example.com/uploads",
+                            repo = "fake/fake"
+                        )
+                    )
+                    application {
+                        install(ContentNegotiation) { json() }
+                        install(StatusPages) { grunnmurExceptionHandlers() }
+                        routing {
+                            gitHubIssueRoutes(GitHubIssueRoutesConfig(
+                                issueService = fakeService,
+                                imageService = imageService,
+                                rateLimiter = RateLimiter(maxAttempts = 100, windowMs = 60_000),
+                                webhookSecret = "test-secret"
+                            ))
+                        }
+                    }
+                    val response = client.post("/api/issues") {
+                        setBody(MultiPartFormDataContent(formData {
+                            append("title", "Test")
+                            append("senderName", "Test Bruker")
+                            append("senderEmail", "test@example.com")
+                            append("description", "Beskrivelse")
+                            repeat(2) { append(imagePart(it, pngBytes())) }
+                        }))
+                    }
+                    assertEquals(HttpStatusCode.Created, response.status)
+                    val parsed = Json { ignoreUnknownKeys = true }
+                        .decodeFromString<CreateIssueResponse>(response.bodyAsText())
+                    assertEquals(2, parsed.imageUrls.size, "Alle 2 bilder skal lastes opp uten imageRateLimiter")
+                }
+            } finally {
+                server.stop(0)
+                uploadDir.toFile().deleteRecursively()
             }
         }
     }

--- a/src/test/kotlin/no/grunnmur/RateLimitPresetsTest.kt
+++ b/src/test/kotlin/no/grunnmur/RateLimitPresetsTest.kt
@@ -373,6 +373,22 @@ class RateLimitPresetsTest {
         assertFalse(limiter.isAllowed("ip1", "phone99"), "6. forsoek fra samme IP skal blokkeres")
     }
 
+    // --- imageUploadRateLimiter preset ---
+
+    @Test
+    fun `imageUploadRateLimiter tillater standard 12 bilder per time`() {
+        val limiter = imageUploadRateLimiter()
+        repeat(12) { assertTrue(limiter.isAllowed("ip1"), "Bilde ${it + 1} skal vaere tillatt") }
+        assertFalse(limiter.isAllowed("ip1"), "13. bilde skal blokkeres")
+    }
+
+    @Test
+    fun `imageUploadRateLimiter respekterer konfigurerbare grenser`() {
+        val limiter = imageUploadRateLimiter(maxImages = 3, windowMs = 60_000)
+        repeat(3) { assertTrue(limiter.isAllowed("ip1")) }
+        assertFalse(limiter.isAllowed("ip1"), "4. bilde skal blokkeres")
+    }
+
 }
 
 /**


### PR DESCRIPTION
Fixes #227

## Summary
- Legger til `imageRateLimiter: KeyRateLimiter? = null` i `GitHubIssueRoutesConfig` — sjekkes per bilde i opplastingsløkken for å begrense aggregert diskbelastning på tvers av forespørsler
- Legger til `maxImagesPerRequest: Int = 3` — avviser forespørsler med for mange bilder (400) og capper minnebruk under multipart-parsing
- Legger til `imageUploadRateLimiter()` preset (12 bilder/time per IP som standard)
- Bakoverkompatibelt: begge nye felt har defaults, eksisterende kallsteder kompilerer uendret

## Test plan
- [x] `for mange bilder gir 400` — verifiserer 400 når antall bilder > `maxImagesPerRequest`
- [x] `imageRateLimiter stopper bildeopplasting naar kvoten er oppbrukt` — verifiserer at issue opprettes men kun 1 bilde lastes opp med kvote på 1
- [x] `uten imageRateLimiter lastes alle bilder opp` — bakoverkompatibilitet
- [x] `imageUploadRateLimiter tillater standard 12 bilder per time`
- [x] `imageUploadRateLimiter respekterer konfigurerbare grenser`

🤖 Generated with [Claude Code](https://claude.com/claude-code)