### PR TITLE
Refactor #223: AtomicLong i RateLimiter.cleanup()

### DIFF
--- a/src/main/kotlin/no/grunnmur/RateLimiter.kt
+++ b/src/main/kotlin/no/grunnmur/RateLimiter.kt
@@ -1,6 +1,7 @@
 package no.grunnmur
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Felles interface for enkle nøkkel-baserte rate limitere.
@@ -37,7 +38,7 @@ class RateLimiter(
     private data class AttemptRecord(val count: Int, val windowStart: Long)
 
     private val attempts = ConcurrentHashMap<String, AttemptRecord>()
-    @Volatile private var lastCleanup = System.currentTimeMillis()
+    private val lastCleanup = AtomicLong(System.currentTimeMillis())
     private val cleanupIntervalMs = 60_000L
 
     /**
@@ -119,16 +120,14 @@ class RateLimiter(
     fun size(): Int = attempts.size
 
     private fun cleanup(now: Long) {
-        if (now - lastCleanup < cleanupIntervalMs) return
-        synchronized(this) {
-            if (now - lastCleanup < cleanupIntervalMs) return
-            attempts.entries.removeIf { now - it.value.windowStart > windowMs }
-            if (attempts.size > maxEntries) {
-                val sorted = attempts.entries.sortedBy { it.value.windowStart }
-                val toRemove = sorted.take(attempts.size - maxEntries)
-                toRemove.forEach { attempts.remove(it.key) }
-            }
-            lastCleanup = now
+        val last = lastCleanup.get()
+        if (now - last < cleanupIntervalMs) return
+        if (!lastCleanup.compareAndSet(last, now)) return
+        attempts.entries.removeIf { now - it.value.windowStart > windowMs }
+        if (attempts.size > maxEntries) {
+            val sorted = attempts.entries.sortedBy { it.value.windowStart }
+            val toRemove = sorted.take(attempts.size - maxEntries)
+            toRemove.forEach { attempts.remove(it.key) }
         }
     }
 }

--- a/src/test/kotlin/no/grunnmur/RateLimiterTest.kt
+++ b/src/test/kotlin/no/grunnmur/RateLimiterTest.kt
@@ -131,6 +131,31 @@ class RateLimiterTest {
     }
 
     @Test
+    fun `cleanup fra to traader samtidig gir ikke negativ size`() {
+        val limiter = RateLimiter(maxAttempts = 5, windowMs = 50, maxEntries = 10_000)
+        val keyCount = 200
+        repeat(keyCount) { i -> limiter.isAllowed("key-$i") }
+        assertEquals(keyCount, limiter.size())
+
+        Thread.sleep(100)
+
+        val threadCount = 2
+        val barrier = CyclicBarrier(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        val futures = (1..threadCount).map {
+            executor.submit {
+                barrier.await()
+                limiter.isAllowed("trigger-cleanup-$it")
+            }
+        }
+        futures.forEach { it.get(10, TimeUnit.SECONDS) }
+        executor.shutdown()
+
+        assertTrue(limiter.size() >= 0, "size() skal aldri vaere negativ etter concurrent cleanup")
+    }
+
+    @Test
     fun `size returnerer antall aktive entries`() {
         val limiter = RateLimiter(maxAttempts = 5)
         assertEquals(0, limiter.size())


### PR DESCRIPTION
Fixes #223

Bytter `@Volatile` + `synchronized(this)` double-checked locking i `cleanup()` til `AtomicLong.compareAndSet`. Gjør hele klassen konsistent lock-free (ConcurrentHashMap + AtomicLong) og eliminerer blandingen av to separate synkroniseringsparadigmer.