### PR TITLE
Fix #223 QA: cleanup-test og TOCTOU i maxEntries

### DIFF
--- a/src/main/kotlin/no/grunnmur/RateLimiter.kt
+++ b/src/main/kotlin/no/grunnmur/RateLimiter.kt
@@ -33,13 +33,13 @@ interface KeyRateLimiter {
 class RateLimiter(
     private val maxAttempts: Int = 5,
     val windowMs: Long = 300_000,
-    private val maxEntries: Int = 10_000
+    private val maxEntries: Int = 10_000,
+    private val cleanupIntervalMs: Long = 60_000
 ) : KeyRateLimiter {
     private data class AttemptRecord(val count: Int, val windowStart: Long)
 
     private val attempts = ConcurrentHashMap<String, AttemptRecord>()
     private val lastCleanup = AtomicLong(System.currentTimeMillis())
-    private val cleanupIntervalMs = 60_000L
 
     /**
      * Sjekker om en noekkel er tillatt og registrerer forsoekets.
@@ -124,9 +124,10 @@ class RateLimiter(
         if (now - last < cleanupIntervalMs) return
         if (!lastCleanup.compareAndSet(last, now)) return
         attempts.entries.removeIf { now - it.value.windowStart > windowMs }
-        if (attempts.size > maxEntries) {
+        val currentSize = attempts.size
+        if (currentSize > maxEntries) {
             val sorted = attempts.entries.sortedBy { it.value.windowStart }
-            val toRemove = sorted.take(attempts.size - maxEntries)
+            val toRemove = sorted.take(currentSize - maxEntries)
             toRemove.forEach { attempts.remove(it.key) }
         }
     }

--- a/src/test/kotlin/no/grunnmur/RateLimiterTest.kt
+++ b/src/test/kotlin/no/grunnmur/RateLimiterTest.kt
@@ -132,7 +132,7 @@ class RateLimiterTest {
 
     @Test
     fun `cleanup fra to traader samtidig gir ikke negativ size`() {
-        val limiter = RateLimiter(maxAttempts = 5, windowMs = 50, maxEntries = 10_000)
+        val limiter = RateLimiter(maxAttempts = 5, windowMs = 50, maxEntries = 10_000, cleanupIntervalMs = 50)
         val keyCount = 200
         repeat(keyCount) { i -> limiter.isAllowed("key-$i") }
         assertEquals(keyCount, limiter.size())
@@ -152,7 +152,7 @@ class RateLimiterTest {
         futures.forEach { it.get(10, TimeUnit.SECONDS) }
         executor.shutdown()
 
-        assertTrue(limiter.size() >= 0, "size() skal aldri vaere negativ etter concurrent cleanup")
+        assertTrue(limiter.size() < keyCount, "Utgaatte entries skal vaere fjernet etter cleanup")
     }
 
     @Test


### PR DESCRIPTION
Oppfølging etter #232 (QA-funn).

- Testen verifiserer nå at utgåtte entries faktisk fjernes etter concurrent cleanup (ikke bare at size >= 0)
- `cleanupIntervalMs` eksponert som constructor-parameter for testbarhet
- `attempts.size` snapshottet til lokal variabel i maxEntries-blokken for å eliminere TOCTOU