### PR TITLE
Fix #236: replay-beskyttelse i TotpService.verifyTotp()

### DIFF
--- a/src/main/kotlin/no/grunnmur/TotpService.kt
+++ b/src/main/kotlin/no/grunnmur/TotpService.kt
@@ -3,6 +3,7 @@ package no.grunnmur
 import dev.turingcomplete.kotlinonetimepassword.HmacAlgorithm
 import dev.turingcomplete.kotlinonetimepassword.TimeBasedOneTimePasswordConfig
 import dev.turingcomplete.kotlinonetimepassword.TimeBasedOneTimePasswordGenerator
+import java.security.MessageDigest
 import java.security.SecureRandom
 import java.time.Instant
 import java.util.Base64
@@ -56,28 +57,50 @@ object TotpService {
      */
     fun confirmTotp(encryptedSecret: String, encryptionKey: String, code: String): Boolean {
         val secretBytes = decryptSecret(encryptedSecret, encryptionKey) ?: return false
-        return verifyCode(secretBytes, code)
+        return verifyCode(secretBytes, code) != null
     }
 
     /**
      * Verifiserer en TOTP-kode ved innlogging.
      *
+     * **Replay-beskyttelse**: TOTP-koden er gyldig i ±[WINDOW_SIZE] tidssteg (±60 sekunder, totalt 120s).
+     * For å hindre gjenbruk av en avlyttet kode innenfor dette vinduet, send inn et trådsikkert sett
+     * via [usedCodes] (`ConcurrentHashMap.newKeySet()`). Grunnmur avviser koden hvis den allerede er
+     * brukt og registrerer vellykket bruk atomisk. Nøkkelen som lagres er `sha256(secret):timeStep`
+     * — ikke råkoden — slik at settet kan deles på tvers av brukere uten kollisjon.
+     *
+     * **Begrensninger**: Settet er prosess-lokalt. Ved horisontal skalering (flere instanser) gir
+     * ikke et lokalt sett replay-beskyttelse på tvers av noder — bruk et delt lager (f.eks. Redis)
+     * i slike oppsett. Uten [usedCodes] (default null) er replay tillatt — bakoverkompatibel oppførsel.
+     *
      * @param encryptedSecret Kryptert hemmelighet fra databasen
      * @param encryptionKey 64 hex-tegn AES-256-nokkel
      * @param code 6-sifret TOTP-kode fra autentiserings-appen
-     * @param devMode Hvis true, aksepteres "123456" alltid (for utvikling — samme som OtpUtils.DEV_CODE)
-     * @return true hvis koden er gyldig
+     * @param devMode Hvis true, aksepteres "123456" alltid (replay-sjekk hoppes over i dev-modus)
+     * @param usedCodes Trådsikkert sett for replay-beskyttelse (`ConcurrentHashMap.newKeySet()`).
+     *   Null = ingen replay-sjekk (bakoverkompatibel). Appen er ansvarlig for TTL/cleanup.
+     * @return true hvis koden er gyldig og ikke allerede brukt
      */
     fun verifyTotp(
         encryptedSecret: String,
         encryptionKey: String,
         code: String,
-        devMode: Boolean = false
+        devMode: Boolean = false,
+        usedCodes: MutableSet<String>? = null
     ): Boolean {
         if (devMode && code == DEV_TOTP_CODE) return true
 
         val secretBytes = decryptSecret(encryptedSecret, encryptionKey) ?: return false
-        return verifyCode(secretBytes, code)
+        val matchedCounter = verifyCode(secretBytes, code) ?: return false
+
+        if (usedCodes != null) {
+            val secretHash = MessageDigest.getInstance("SHA-256").digest(secretBytes)
+                .take(16).joinToString("") { "%02x".format(it) }
+            val replayKey = "$secretHash:$matchedCounter"
+            if (!usedCodes.add(replayKey)) return false
+        }
+
+        return true
     }
 
     /**
@@ -153,7 +176,7 @@ object TotpService {
         return Base64.getDecoder().decode(secret)
     }
 
-    private fun verifyCode(secretBytes: ByteArray, code: String): Boolean {
+    private fun verifyCode(secretBytes: ByteArray, code: String): Long? {
         val config = TimeBasedOneTimePasswordConfig(
             timeStep = TIME_STEP_SECONDS.toLong(),
             timeStepUnit = TimeUnit.SECONDS,
@@ -166,9 +189,9 @@ object TotpService {
         for (offset in -WINDOW_SIZE..WINDOW_SIZE) {
             val timestamp = now.plusSeconds(offset * TIME_STEP_SECONDS.toLong())
             val expectedCode = generator.generate(timestamp)
-            if (code == expectedCode) return true
+            if (code == expectedCode) return timestamp.epochSecond / TIME_STEP_SECONDS
         }
-        return false
+        return null
     }
 
     private fun buildOtpAuthUri(secretBytes: ByteArray, issuer: String, accountName: String): String {

--- a/src/test/kotlin/no/grunnmur/TotpServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/TotpServiceTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 class TotpServiceTest {
@@ -131,6 +132,78 @@ class TotpServiceTest {
             val code = generateTotpCode(secretBytes)
 
             assertTrue(TotpService.verifyTotp(encryptedSecret, testKey, code))
+        }
+    }
+
+    @Nested
+    inner class ReplayBeskyttelse {
+        @Test
+        fun `samme kode avvises ved andre forsok med usedCodes-sett`() {
+            val secretBytes = ByteArray(20) { it.toByte() }
+            val encryptedSecret = encryptedSecretFrom(secretBytes)
+            val code = generateTotpCode(secretBytes)
+            val usedCodes = ConcurrentHashMap.newKeySet<String>()
+
+            assertTrue(TotpService.verifyTotp(encryptedSecret, testKey, code, usedCodes = usedCodes))
+            assertFalse(TotpService.verifyTotp(encryptedSecret, testKey, code, usedCodes = usedCodes))
+        }
+
+        @Test
+        fun `godkjent kode registreres i usedCodes`() {
+            val secretBytes = ByteArray(20) { it.toByte() }
+            val encryptedSecret = encryptedSecretFrom(secretBytes)
+            val code = generateTotpCode(secretBytes)
+            val usedCodes = ConcurrentHashMap.newKeySet<String>()
+
+            assertTrue(TotpService.verifyTotp(encryptedSecret, testKey, code, usedCodes = usedCodes))
+            assertTrue(usedCodes.isNotEmpty(), "Brukt kode skal registreres i settet")
+        }
+
+        @Test
+        fun `ugyldig kode legges ikke til i usedCodes`() {
+            val secretBytes = ByteArray(20) { it.toByte() }
+            val encryptedSecret = encryptedSecretFrom(secretBytes)
+            val usedCodes = ConcurrentHashMap.newKeySet<String>()
+
+            assertFalse(TotpService.verifyTotp(encryptedSecret, testKey, "000000", usedCodes = usedCodes))
+            assertTrue(usedCodes.isEmpty(), "Ugyldig kode skal ikke registreres")
+        }
+
+        @Test
+        fun `uten usedCodes er replay tillatt (bakoverkompatibel)`() {
+            val secretBytes = ByteArray(20) { it.toByte() }
+            val encryptedSecret = encryptedSecretFrom(secretBytes)
+            val code = generateTotpCode(secretBytes)
+
+            assertTrue(TotpService.verifyTotp(encryptedSecret, testKey, code))
+            assertTrue(TotpService.verifyTotp(encryptedSecret, testKey, code))
+        }
+
+        @Test
+        fun `dev-modus 123456 er unntatt fra replay-sjekk`() {
+            val secretBytes = ByteArray(20) { it.toByte() }
+            val encryptedSecret = encryptedSecretFrom(secretBytes)
+            val usedCodes = ConcurrentHashMap.newKeySet<String>()
+
+            assertTrue(TotpService.verifyTotp(encryptedSecret, testKey, "123456", devMode = true, usedCodes = usedCodes))
+            assertTrue(TotpService.verifyTotp(encryptedSecret, testKey, "123456", devMode = true, usedCodes = usedCodes))
+        }
+
+        @Test
+        fun `koder fra ulike brukere kolliderer ikke i delt sett`() {
+            val secretBytes1 = ByteArray(20) { it.toByte() }
+            val secretBytes2 = ByteArray(20) { (it + 100).toByte() }
+            val encrypted1 = encryptedSecretFrom(secretBytes1)
+            val encrypted2 = encryptedSecretFrom(secretBytes2)
+            val code1 = generateTotpCode(secretBytes1)
+            val code2 = generateTotpCode(secretBytes2)
+            val sharedUsedCodes = ConcurrentHashMap.newKeySet<String>()
+
+            // Begge brukere kan autentisere selv om de deler sett
+            assertTrue(TotpService.verifyTotp(encrypted1, testKey, code1, usedCodes = sharedUsedCodes))
+            // Kode fra bruker2 skal ikke bli blokkert av bruker1s oppføring
+            if (code1 == code2) return // Ekstremt sjelden kollisjon — skip test
+            assertTrue(TotpService.verifyTotp(encrypted2, testKey, code2, usedCodes = sharedUsedCodes))
         }
     }
 


### PR DESCRIPTION
Fixes #236

Legger til valgfri `usedCodes: MutableSet<String>?`-parameter i `verifyTotp()` for å hindre gjenbruk av TOTP-kode innenfor 120s-vinduet (RFC 6238 §5.2).

**Endringer:**
- `verifyCode()` returnerer nå `Long?` (matchet tidssteg) i stedet for `Boolean`
- `verifyTotp()` sjekker `usedCodes` atomisk via `ConcurrentHashSet.add()` etter vellykket verifisering
- Nøkkel i settet er `sha256(secret):timeStep` — ikke råkoden — for å unngå kryssbruker-kollisjoner ved delt sett
- Dev-mode 123456 hopper over replay-sjekk (uendret dev-flyt)
- Null-default bevarer bakoverkompatibilitet — eksisterende kallessteder uberørt
- KDoc dokumenterer prosess-lokal begrensning (horisontal skalering krever delt lager)