### PR TITLE
Fix #236 QA: styrk replay-tester og KDoc TTL-advarsel

### DIFF
--- a/src/main/kotlin/no/grunnmur/TotpService.kt
+++ b/src/main/kotlin/no/grunnmur/TotpService.kt
@@ -78,7 +78,9 @@ object TotpService {
      * @param code 6-sifret TOTP-kode fra autentiserings-appen
      * @param devMode Hvis true, aksepteres "123456" alltid (replay-sjekk hoppes over i dev-modus)
      * @param usedCodes Trådsikkert sett for replay-beskyttelse (`ConcurrentHashMap.newKeySet()`).
-     *   Null = ingen replay-sjekk (bakoverkompatibel). Appen er ansvarlig for TTL/cleanup.
+     *   Null = ingen replay-sjekk (bakoverkompatibel). Appen er ansvarlig for TTL/cleanup —
+     *   uten periodisk tømming vokser settet ubegrenset. Counters eldre enn 120 sekunder kan
+     *   trygt fjernes (to tidssteg à 30s på hver side av nåtid).
      * @return true hvis koden er gyldig og ikke allerede brukt
      */
     fun verifyTotp(

--- a/src/test/kotlin/no/grunnmur/TotpServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/TotpServiceTest.kt
@@ -199,11 +199,22 @@ class TotpServiceTest {
             val code2 = generateTotpCode(secretBytes2)
             val sharedUsedCodes = ConcurrentHashMap.newKeySet<String>()
 
-            // Begge brukere kan autentisere selv om de deler sett
+            // Begge brukere kan autentisere selv om de deler sett.
+            // Nøkkelen i usedCodes er secretHash:counter — ikke råkoden — så lik 6-sifret kode er
+            // ikke en kollisjon: ulike hemmeligheter gir ulike secretHash og dermed ulike nøkler.
             assertTrue(TotpService.verifyTotp(encrypted1, testKey, code1, usedCodes = sharedUsedCodes))
-            // Kode fra bruker2 skal ikke bli blokkert av bruker1s oppføring
-            if (code1 == code2) return // Ekstremt sjelden kollisjon — skip test
             assertTrue(TotpService.verifyTotp(encrypted2, testKey, code2, usedCodes = sharedUsedCodes))
+        }
+
+        @Test
+        fun `confirmTotp er uberort av replay-logikk`() {
+            val secretBytes = ByteArray(20) { it.toByte() }
+            val encryptedSecret = encryptedSecretFrom(secretBytes)
+            val code = generateTotpCode(secretBytes)
+
+            // confirmTotp har ingen usedCodes-parameter — replay er ikke relevant under TOTP-oppsett
+            assertTrue(TotpService.confirmTotp(encryptedSecret, testKey, code))
+            assertTrue(TotpService.confirmTotp(encryptedSecret, testKey, code))
         }
     }
 


### PR DESCRIPTION
Oppfølging etter QA-review av #240 (issue #236).

**Funn fikset:**
- **M2**: Kryssbrukertesten hadde feil skip-logikk (`if (code1 == code2) return`). Nøkkelen i `usedCodes` er `secretHash:counter` — ikke råkoden — så identiske 6-sifrede koder fra ulike brukere gir aldri kollisjon. Skip-sjekken fjernet.
- **M3**: Lagt til test som bekrefter at `confirmTotp()` er uberørt av replay-logikk (ingen `usedCodes`-parameter, gjenbruk er tillatt under oppsett).
- **F3**: KDoc for `usedCodes`-parameteren advarer nå om at settet vokser ubegrenset uten cleanup, og at counters eldre enn 120s kan fjernes trygt.