### PR TITLE
Fix #237: AuditLogs.id INTEGER → BIGINT (SERIAL → BIGSERIAL)

### DIFF
--- a/src/main/kotlin/no/grunnmur/AuditLogService.kt
+++ b/src/main/kotlin/no/grunnmur/AuditLogService.kt
@@ -175,7 +175,7 @@ class AuditLogService {
  * DTO for en audit-logg-entry.
  */
 data class AuditLogEntry(
-    val id: Int,
+    val id: Long,
     val userId: Int?,
     val userEmail: String,
     val action: String,

--- a/src/main/kotlin/no/grunnmur/AuditLogTable.kt
+++ b/src/main/kotlin/no/grunnmur/AuditLogTable.kt
@@ -10,7 +10,7 @@ import org.jetbrains.exposed.v1.javatime.datetime
  * Migrering (SQL):
  * ```sql
  * CREATE TABLE IF NOT EXISTS audit_logs (
- *     id SERIAL PRIMARY KEY,
+ *     id BIGSERIAL PRIMARY KEY,
  *     user_id INTEGER,
  *     user_email VARCHAR(255) NOT NULL DEFAULT 'system',
  *     action VARCHAR(100) NOT NULL,
@@ -26,7 +26,7 @@ import org.jetbrains.exposed.v1.javatime.datetime
  * ```
  */
 object AuditLogs : Table("audit_logs") {
-    val id = integer("id").autoIncrement()
+    val id = long("id").autoIncrement()
     val userId = integer("user_id").nullable()
     val userEmail = varchar("user_email", 255).default("system")
     val action = varchar("action", 100)

--- a/src/test/kotlin/no/grunnmur/AuditLogServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/grunnmur/AuditLogServiceIntegrationTest.kt
@@ -130,6 +130,16 @@ class AuditLogServiceIntegrationTest {
     }
 
     @Test
+    fun `AuditLogEntry id er Long ikke Int mot ekte PostgreSQL`() = runBlocking {
+        service.log(userId = 1, action = "TYPE_CHECK", entityType = "TEST")
+        val entries = service.findAll()
+        assertEquals(1, entries.size)
+        // id skal være Long (BIGSERIAL) — vil ikke kompilere hvis id er Int
+        val id: Long = entries[0].id
+        assertTrue(id > 0L)
+    }
+
+    @Test
     fun `cleanupOldLogs sletter rader eldre enn retentionDays mot ekte PostgreSQL`() = runBlocking {
         val now = TimeUtils.nowOslo()
         insertWithCreatedAt("GAMMEL", now.minusDays(400))

--- a/src/test/kotlin/no/grunnmur/AuditLogServiceTest.kt
+++ b/src/test/kotlin/no/grunnmur/AuditLogServiceTest.kt
@@ -339,6 +339,19 @@ class AuditLogServiceTest {
     }
 
     @Nested
+    inner class IdType {
+        @Test
+        fun `AuditLogEntry id er Long ikke Int`() = runBlocking {
+            service.log(userId = 1, action = "TYPE_CHECK", entityType = "TEST")
+            val entries = service.findAll()
+            assertEquals(1, entries.size)
+            // id skal være Long (BIGSERIAL) — vil ikke kompilere hvis id er Int
+            val id: Long = entries[0].id
+            assertTrue(id > 0L)
+        }
+    }
+
+    @Nested
     inner class CleanupOldLogs {
         @Test
         fun `cleanupOldLogs returnerer 0 naar ingen er eldre enn retention`() = runBlocking {


### PR DESCRIPTION
Fixes #237

Bytter primærnøkkelen i `AuditLogs` fra `INTEGER` (SERIAL, maks ~2,1 mrd) til `BIGINT` (BIGSERIAL, maks ~9,2 × 10^18) for å forhindre overflow ved høy audit-loggfrekvens.

**Endringer:**
- `AuditLogTable.kt`: `integer("id").autoIncrement()` → `long("id").autoIncrement()`
- `AuditLogService.kt`: `AuditLogEntry.id: Int` → `AuditLogEntry.id: Long`
- KDoc oppdatert: SERIAL → BIGSERIAL i eksempel-DDL
- Tester: Long-type-assertions lagt til i begge testklasser (kompilerer ikke med Int)