### PR TITLE
Fix #243: dokumenter audit_logs INTEGER→BIGINT oppgraderingssti

### DIFF
--- a/src/main/kotlin/no/grunnmur/AuditLogTable.kt
+++ b/src/main/kotlin/no/grunnmur/AuditLogTable.kt
@@ -24,6 +24,17 @@ import org.jetbrains.exposed.v1.javatime.datetime
  * CREATE INDEX IF NOT EXISTS idx_audit_logs_created ON audit_logs(created_at);
  * CREATE INDEX IF NOT EXISTS idx_audit_logs_user ON audit_logs(user_id);
  * ```
+ *
+ * Oppgradering av eksisterende installasjoner (id var tidligere SERIAL/INTEGER):
+ * `id` er nå `BIGINT` (BIGSERIAL) for å unngå overflow ved langtidsdrift. Apper
+ * med en eldre `audit_logs`-tabell opprettet med `id SERIAL PRIMARY KEY` har
+ * fortsatt en INTEGER-kolonne (tak ~2,1 mrd) i databasen. Exposed leser INTEGER
+ * via `long("id")` uten feil (Int→Long widening), så oppgraderingen krasjer
+ * ikke — men for faktisk å få BIGINT-taket må hver app kjøre en Flyway-migrasjon:
+ * ```sql
+ * ALTER SEQUENCE audit_logs_id_seq AS bigint;  -- PostgreSQL 10+
+ * ALTER TABLE audit_logs ALTER COLUMN id TYPE BIGINT;
+ * ```
  */
 object AuditLogs : Table("audit_logs") {
     val id = long("id").autoIncrement()


### PR DESCRIPTION
Fixes #243

Review-gate-oppfølging for PR #242 (#237).

## Vurdering av MAJOR-funnet
- **Delvis false positive**: Claimen om runtime type-mismatch-krasj er feil. Exposed sin `LongColumnType.valueFromDB` widener Int→Long uten unntak (både lesing og autoIncrement-insert mot int4-sekvens), og grunnmur kaller aldri `SchemaUtils.create` → ingen DDL-validering mot DB. Apper krasjer ikke ved oppgradering.
- **Reell kjerne**: En apps `audit_logs.id` forblir INTEGER (2,1 mrd-tak) til den kjører `ALTER TABLE`. Overflow-beskyttelsen #237 var ment å gi, leveres altså ikke til appene av grunnmur-typeendringen alene. Pre-eksisterende tilstand, ikke regresjon — men oppgraderingsstien var udokumentert.

## Endring
Legger eksplisitt `ALTER`-migrasjonsnote i KDoc i `AuditLogTable.kt`:
```sql
ALTER SEQUENCE audit_logs_id_seq AS bigint;  -- PostgreSQL 10+
ALTER TABLE audit_logs ALTER COLUMN id TYPE BIGINT;
```

Doc-only KDoc-endring — ingen meningsfull enhetstest (TDD-unntak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)