### PR TITLE
Fix #239: findAllPaged() i AuditLogService + KDoc-advarsel i getClientIp()

### DIFF
--- a/src/main/kotlin/no/grunnmur/AuditLogService.kt
+++ b/src/main/kotlin/no/grunnmur/AuditLogService.kt
@@ -107,6 +107,43 @@ class AuditLogService {
     }
 
     /**
+     * Henter revisjonslogger med filtrering og paginering i én transaksjon.
+     *
+     * I motsetning til separate kall til [findAll] og [count] kjoeres baade
+     * uthenting av rader og total-telling innenfor samme transaction{}-blokk,
+     * slik at items og total er konsistente (ingen ghost reads mellom de to spoerringene).
+     *
+     * @return [PaginatedResponse] med items for gjeldende side og total antall rader som matcher filteret.
+     */
+    suspend fun findAllPaged(
+        action: String? = null,
+        entityType: String? = null,
+        userId: Int? = null,
+        startDate: String? = null,
+        endDate: String? = null,
+        limit: Int = 100,
+        offset: Long = 0
+    ): PaginatedResponse<AuditLogEntry> {
+        val effectiveLimit = limit.coerceIn(1, MAX_LIMIT)
+        return withContext(Dispatchers.IO) {
+            transaction {
+                val totalQuery = AuditLogs.selectAll()
+                applyFilters(totalQuery, action, entityType, userId, startDate, endDate)
+                val total = totalQuery.count()
+
+                val itemsQuery = AuditLogs.selectAll()
+                applyFilters(itemsQuery, action, entityType, userId, startDate, endDate)
+                val items = itemsQuery
+                    .orderBy(AuditLogs.createdAt, SortOrder.DESC)
+                    .limit(effectiveLimit).offset(offset)
+                    .map { it.toAuditLogEntry() }
+
+                PaginatedResponse(items = items, total = total, limit = effectiveLimit, offset = offset)
+            }
+        }
+    }
+
+    /**
      * Sletter gamle logger basert paa retention-policy.
      * @return Antall slettede rader
      */

--- a/src/main/kotlin/no/grunnmur/RouteUtils.kt
+++ b/src/main/kotlin/no/grunnmur/RouteUtils.kt
@@ -55,6 +55,14 @@ fun ApplicationCall.checkRateLimit(
  * 2. X-Real-IP (Nginx)
  * 3. X-Forwarded-For (standard proxy-header, foerste IP)
  * 4. remoteAddress (direkte tilkobling / fallback)
+ *
+ * **ADVARSEL — SPOOFING:** Alle headers (X-Forwarded-For, X-Real-IP) kan forfalskes av klienten
+ * ved direkte containertilgang eller i testmiljoeer uten proxy. CF-Connecting-IP er kun paalitelig
+ * naar trafikken faktisk gaar gjennom Cloudflare-proxyen.
+ *
+ * For rate limiting er spoofbar IP akseptabelt (degraderer til mindre presis nokkel).
+ * Bruk den ALDRI som eneste sikkerhetsgrense for tilgangskontroll eller IP-allowlisting
+ * uten at en betrodd proxy garanterer headerverdien.
  */
 fun ApplicationCall.getClientIp(): String {
     return request.header("CF-Connecting-IP")

--- a/src/test/kotlin/no/grunnmur/AuditLogServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/grunnmur/AuditLogServiceIntegrationTest.kt
@@ -193,4 +193,81 @@ class AuditLogServiceIntegrationTest {
         assertEquals(2, listResult.size)
         assertEquals(countResult, listResult.size.toLong())
     }
+
+    @Test
+    fun `findAllPaged total ignorerer limit og offset mot ekte PostgreSQL`() = runBlocking {
+        val now = TimeUtils.nowOslo()
+        repeat(5) { insertWithCreatedAt("A", now.minusMinutes(it.toLong())) }
+
+        val result = service.findAllPaged(limit = 2)
+
+        assertEquals(2, result.items.size)
+        assertEquals(5L, result.total)
+        assertEquals(2, result.limit)
+        assertEquals(0L, result.offset)
+    }
+
+    @Test
+    fun `findAllPaged offset returnerer korrekt side med uendret total mot ekte PostgreSQL`() = runBlocking {
+        val now = TimeUtils.nowOslo()
+        repeat(5) { insertWithCreatedAt("A", now.minusMinutes(it.toLong())) }
+
+        val result = service.findAllPaged(limit = 2, offset = 2)
+
+        assertEquals(2, result.items.size)
+        assertEquals(5L, result.total)
+    }
+
+    @Test
+    fun `findAllPaged filter pavirker items og total konsistent mot ekte PostgreSQL`() = runBlocking {
+        val now = TimeUtils.nowOslo()
+        repeat(3) { insertWithCreatedAt("TYPE_A", now.minusMinutes(it.toLong())) }
+        repeat(2) { insertWithCreatedAt("TYPE_B", now.minusMinutes(it.toLong())) }
+
+        val result = service.findAllPaged(action = "TYPE_A")
+
+        assertEquals(3, result.items.size)
+        assertEquals(3L, result.total)
+        assertTrue(result.items.all { it.action == "TYPE_A" })
+    }
+
+    @Test
+    fun `findAllPaged limit 0 clampes til 1 mot ekte PostgreSQL`() = runBlocking {
+        insertWithCreatedAt("A", TimeUtils.nowOslo())
+
+        val result = service.findAllPaged(limit = 0)
+
+        assertEquals(1, result.limit)
+        assertEquals(1, result.items.size)
+    }
+
+    @Test
+    fun `findAllPaged limit over MAX_LIMIT clampes mot ekte PostgreSQL`() = runBlocking {
+        repeat(3) { insertWithCreatedAt("A", TimeUtils.nowOslo().minusMinutes(it.toLong())) }
+
+        val result = service.findAllPaged(limit = 5000)
+
+        assertEquals(AuditLogService.MAX_LIMIT, result.limit)
+        assertEquals(3, result.items.size)
+    }
+
+    @Test
+    fun `findAllPaged returnerer tom items og total 0 naar filter ikke matcher mot ekte PostgreSQL`() = runBlocking {
+        insertWithCreatedAt("FINNES", TimeUtils.nowOslo())
+
+        val result = service.findAllPaged(action = "FINNES_IKKE")
+
+        assertTrue(result.items.isEmpty())
+        assertEquals(0L, result.total)
+    }
+
+    @Test
+    fun `findAllPaged offset utenfor omradet returnerer tom items men korrekt total mot ekte PostgreSQL`() = runBlocking {
+        repeat(3) { insertWithCreatedAt("A", TimeUtils.nowOslo().minusMinutes(it.toLong())) }
+
+        val result = service.findAllPaged(limit = 10, offset = 100)
+
+        assertTrue(result.items.isEmpty())
+        assertEquals(3L, result.total)
+    }
 }


### PR DESCRIPTION
Fixes #239

## Endringer

**C) AuditLogService.findAllPaged()** — ny metode som returnerer `PaginatedResponse<AuditLogEntry>` med items og total i én atomisk `transaction{}`-blokk. Løser ghost-read-problemet mellom separate `findAll()`/`count()`-kall. `findAll()` og `count()` beholdes uendret for bakoverkompatibilitet.

**B) getClientIp() KDoc** — dokumenterer at X-Forwarded-For og X-Real-IP kan forfalskes ved direkte containertilgang eller i testmiljøer uten Cloudflare-proxy. Ingen atferdsendring.

**A) Flyway-tracking** — ingen kodeendring. Status notert i issue-kommentar: pin i build.gradle.kts er korrekt, sporing via dependabot-PRer #79/#80.

## Tester
7 nye integrasjonstester i `AuditLogServiceIntegrationTest` (mot PostgreSQL 16 via Testcontainers):
- Total ignorerer limit/offset
- Korrekt offset-paginering med uendret total
- Filter påvirker både items og total konsistent
- Limit 0 clampes til 1
- Limit over MAX_LIMIT clampes
- Tom result ved ingen match (items=[], total=0)
- Offset utenfor område (items=[], total>0)

Alle 17 integrasjonstester grønne. Full testsuite grønn.