### PR TITLE
Fix QA-funn fra #239: KDoc-presisering og negativ offset-clamping i findAllPaged()

### DIFF
--- a/src/main/kotlin/no/grunnmur/AuditLogService.kt
+++ b/src/main/kotlin/no/grunnmur/AuditLogService.kt
@@ -109,9 +109,11 @@ class AuditLogService {
     /**
      * Henter revisjonslogger med filtrering og paginering i én transaksjon.
      *
-     * I motsetning til separate kall til [findAll] og [count] kjoeres baade
-     * uthenting av rader og total-telling innenfor samme transaction{}-blokk,
-     * slik at items og total er konsistente (ingen ghost reads mellom de to spoerringene).
+     * Kjorer baade uthenting av rader og total-telling innenfor samme transaction{}-blokk,
+     * noe som *reduserer* risikoen for uoverensstemmelse mellom items og total sammenlignet
+     * med to separate transaksjoner. Merk: PostgreSQL bruker READ COMMITTED som standard
+     * isolasjonsnivaa, saa en concurrent-commit mellom de to SELECT-ene kan fortsatt endre
+     * total. For streng konsistens maa isolasjonsnivaaet heves til REPEATABLE READ.
      *
      * @return [PaginatedResponse] med items for gjeldende side og total antall rader som matcher filteret.
      */
@@ -125,6 +127,7 @@ class AuditLogService {
         offset: Long = 0
     ): PaginatedResponse<AuditLogEntry> {
         val effectiveLimit = limit.coerceIn(1, MAX_LIMIT)
+        val effectiveOffset = offset.coerceAtLeast(0L)
         return withContext(Dispatchers.IO) {
             transaction {
                 val totalQuery = AuditLogs.selectAll()
@@ -135,10 +138,10 @@ class AuditLogService {
                 applyFilters(itemsQuery, action, entityType, userId, startDate, endDate)
                 val items = itemsQuery
                     .orderBy(AuditLogs.createdAt, SortOrder.DESC)
-                    .limit(effectiveLimit).offset(offset)
+                    .limit(effectiveLimit).offset(effectiveOffset)
                     .map { it.toAuditLogEntry() }
 
-                PaginatedResponse(items = items, total = total, limit = effectiveLimit, offset = offset)
+                PaginatedResponse(items = items, total = total, limit = effectiveLimit, offset = effectiveOffset)
             }
         }
     }

--- a/src/test/kotlin/no/grunnmur/AuditLogServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/grunnmur/AuditLogServiceIntegrationTest.kt
@@ -270,4 +270,29 @@ class AuditLogServiceIntegrationTest {
         assertTrue(result.items.isEmpty())
         assertEquals(3L, result.total)
     }
+
+    @Test
+    fun `findAllPaged negativ offset clampes til 0 mot ekte PostgreSQL`() = runBlocking {
+        repeat(3) { insertWithCreatedAt("A", TimeUtils.nowOslo().minusMinutes(it.toLong())) }
+
+        val result = service.findAllPaged(limit = 10, offset = -5)
+
+        assertEquals(3, result.items.size)
+        assertEquals(3L, result.total)
+        assertEquals(0L, result.offset)
+    }
+
+    @Test
+    fun `findAllPaged datofilter pavirker baade items og total mot ekte PostgreSQL`() = runBlocking {
+        val now = TimeUtils.nowOslo()
+        insertWithCreatedAt("GAMMEL", now.minusDays(10))
+        insertWithCreatedAt("NY1", now)
+        insertWithCreatedAt("NY2", now.minusHours(1))
+
+        val cutoff = now.minusDays(1).toLocalDate().toString()
+        val result = service.findAllPaged(startDate = cutoff)
+
+        assertEquals(2, result.items.size)
+        assertEquals(2L, result.total)
+    }
 }


### PR DESCRIPTION
QA-oppfølging etter PR #246 (closes #239).

## Endringer

**KDoc-presisering**: Fjernet feilaktig påstand om at `transaction{}` garanterer konsistens mellom items og total. PostgreSQL bruker READ COMMITTED som standard, så concurrent-commit mellom de to SELECT-ene kan fortsatt endre total. KDoc sier nå korrekt at det *reduserer* (ikke eliminerer) risikoen sammenlignet med to separate transaksjoner.

**Negativ offset clamping**: `offset.coerceAtLeast(0L)` hindrer uventet 500-feil ved negativt offset (PostgreSQL avviser negativ OFFSET med exception). Clampet offset returneres i `PaginatedResponse.offset`.

## Nye tester
- `findAllPaged negativ offset clampes til 0` — verifiserer clamping og at offset=0 returneres
- `findAllPaged datofilter pavirker baade items og total` — verifiserer at startDate-filter fungerer korrekt for den nye metoden