### PR TITLE
Fix #238: hev substring-grense til 8 tegn i validatePassword

### DIFF
--- a/src/main/kotlin/no/grunnmur/Validators.kt
+++ b/src/main/kotlin/no/grunnmur/Validators.kt
@@ -207,7 +207,7 @@ object Validators {
 
         val lower = password.lowercase()
         val isCommon = commonPasswordSet.contains(lower) ||
-            commonPasswordSet.any { it.length >= 6 && lower.contains(it) }
+            commonPasswordSet.any { it.length >= 8 && lower.contains(it) }
         if (isCommon || SEASONAL_REGEX.matches(lower)) errors.add("Passord er for enkelt")
 
         return if (errors.isEmpty()) ValidationResult.valid() else ValidationResult(false, errors)

--- a/src/main/resources/common-passwords.txt
+++ b/src/main/resources/common-passwords.txt
@@ -1,6 +1,6 @@
 # Vanlige passord og basisord — brukes til passordstyrkevalidering
 # Format: ett passord/basisord per linje, lowercase
-# Ord med 6+ tegn brukes til substring-sjekk; kortere kun eksakt match
+# Ord med 8+ tegn brukes til substring-sjekk; kortere kun eksakt match
 
 # --- Engelske rotord ---
 password
@@ -186,6 +186,7 @@ ole
 qwerty
 qwertyui
 qwerty123
+qwerty12
 asdfgh
 asdfghjk
 asdfgh12

--- a/src/test/kotlin/no/grunnmur/ValidatorsTest.kt
+++ b/src/test/kotlin/no/grunnmur/ValidatorsTest.kt
@@ -244,6 +244,20 @@ class ValidatorsTest {
             assertFalse(Validators.validatePassword("11111111a").isValid)
             assertFalse(Validators.validatePassword("22222222b").isValid)
         }
+
+        @Test
+        fun `sterke passord med vanlige rotord skal ikke avvises`() {
+            assertTrue(Validators.validatePassword("Daniella2024!").isValid)
+            assertTrue(Validators.validatePassword("Masterchef9000").isValid)
+            assertTrue(Validators.validatePassword("Dragonfly2025!").isValid)
+            assertTrue(Validators.validatePassword("HunterGatherer3!").isValid)
+        }
+
+        @Test
+        fun `lange vanlige basisord avvises fortsatt som substring`() {
+            assertFalse(Validators.validatePassword("password2024!").isValid)
+            assertFalse(Validators.validatePassword("sunshine123!!").isValid)
+        }
     }
 
     @Nested


### PR DESCRIPTION
Fixes #238

Endringer:
- Validators.kt: substring-sjekk endret fra `>= 6` til `>= 8` tegn
- common-passwords.txt: la til manglende `qwerty12` (asdfgh12 og zxcvbn12 var allerede der) + oppdatert kommentar
- ValidatorsTest.kt: lagt til tester for falsk-positiv-scenariet og for at lange basisord fortsatt avvises