### PR TITLE
Fix #256: docs: Ktor-versjon feil i begge docs (3.5.0 → 3.5.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,7 +315,7 @@ Config: `Config(uploadDir, baseUrl, repo = "", maxFileSize = 2MB, maxImagesPerIs
 ## Teknisk
 
 - **Kotlin**: 2.4.0
-- **Ktor**: 3.5.0 (compileOnly — Server + Client CIO)
+- **Ktor**: 3.5.1 (compileOnly — Server + Client CIO)
 - **Exposed**: 1.3.0 (compileOnly)
 - **kotlinx-serialization-json**: 1.11.0 (compileOnly)
 - **Jakarta Mail**: 2.1.5 (compileOnly)

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ services:
 
 ## Versjoner
 
-- Kotlin 2.4.0, Ktor 3.5.0 (Server + Client CIO), Exposed 1.3.0, JVM 25
+- Kotlin 2.4.0, Ktor 3.5.1 (Server + Client CIO), Exposed 1.3.0, JVM 25
 - kotlinx-serialization-json 1.11.0, Jakarta Mail 2.1.5, Flyway 11.19.1
 - kotlin-onetimepassword 2.4.1, SLF4J 2.0.18
 - Testcontainers 1.21.4, PostgreSQL JDBC 42.7.11 (integrasjonstester)


### PR DESCRIPTION
Fixes #256

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.