### PR TITLE
Fix #257: docs: vinforalle fortsatt listet som konsument — prosjektet er revet ned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # grunnmur
 
 Felles Kotlin-bibliotek for alle Ktor-apper i portefoljen.
-Brukes av biologportal, 6810, styreportal, smart-casual, maskemester og vinforalle.
+Brukes av biologportal, 6810, styreportal, smart-casual og maskemester.
 
 ## Komplett modulreferanse (23 filer, 18 moduler)
 

--- a/README.md
+++ b/README.md
@@ -499,4 +499,3 @@ services:
 - [styreportal](https://github.com/TommySkogstad/styreportal)
 - [smart-casual](https://github.com/TommySkogstad/smart-casual)
 - [maskemester](https://github.com/TommySkogstad/maskemester)
-- [vinforalle](https://github.com/TommySkogstad/vinforalle)


### PR DESCRIPTION
Fixes #257

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.