### PR TITLE
fix: add GitHubApiException handler to grunnmurExceptionHandlers

### DIFF
--- a/src/main/kotlin/no/grunnmur/StatusPagesConfig.kt
+++ b/src/main/kotlin/no/grunnmur/StatusPagesConfig.kt
@@ -60,6 +60,14 @@ fun StatusPagesConfig.grunnmurExceptionHandlers(
         )
     }
 
+    exception<GitHubApiException> { call, cause ->
+        call.application.log.warn("GitHub API-feil (status=${cause.statusCode}): ${cause.message}")
+        call.respond(
+            HttpStatusCode.BadGateway,
+            mapOf("error" to "GitHub API er midlertidig utilgjengelig. Proev igjen.")
+        )
+    }
+
     exception<IllegalArgumentException> { call, cause ->
         call.application.log.warn("Ugyldig input: ${cause.message}")
         call.respond(

--- a/src/test/kotlin/no/grunnmur/StatusPagesConfigTest.kt
+++ b/src/test/kotlin/no/grunnmur/StatusPagesConfigTest.kt
@@ -28,6 +28,7 @@ class StatusPagesConfigTest {
                 get("/rate-limit") { throw RateLimitException("Vent litt") }
                 get("/rate-limit-retry") { throw RateLimitException("Vent litt", retryAfterSeconds = 30) }
                 get("/auth") { throw AuthenticationException("Ugyldig token") }
+                get("/github-api") { throw GitHubApiException("GitHub svarte 503", statusCode = 503) }
                 get("/illegal-arg") { throw IllegalArgumentException("Ugyldig argument") }
                 get("/unexpected") { throw RuntimeException("Noe gikk galt") }
             }
@@ -91,6 +92,14 @@ class StatusPagesConfigTest {
             val response = client.get("/auth")
             assertEquals(HttpStatusCode.Unauthorized, response.status)
             assertContains(response.bodyAsText(), "Autentisering feilet")
+        }
+
+        @Test
+        fun `GitHubApiException gir 502`() = testApplication {
+            setupApp()
+            val response = client.get("/github-api")
+            assertEquals(HttpStatusCode.BadGateway, response.status)
+            assertContains(response.bodyAsText(), "GitHub API er midlertidig utilgjengelig")
         }
 
         @Test


### PR DESCRIPTION
The library throws GitHubApiException from GitHubAppAuth/GitHubIssueService
but StatusPagesConfig never mapped it, so all three consumers of
gitHubIssueRoutes had copy-pasted the identical 7-line handler locally.
Without it the exception would have fallen through to the generic
Throwable -> 500 handler instead of 502.

Fixes #263
