### PR TITLE
refactor: add throw-style require helpers to Validators for canonical email regex

### DIFF
--- a/src/main/kotlin/no/grunnmur/Validators.kt
+++ b/src/main/kotlin/no/grunnmur/Validators.kt
@@ -60,6 +60,42 @@ object Validators {
         email.isNotBlank() && email.length < 255 && EMAIL_REGEX.matches(email.trim())
 
     /**
+     * Kaster BadRequestException hvis e-postadressen er ugyldig (kanonisk regex, se validateEmail).
+     * Throw-stil for konsumenter som vil unngaa aa pakke ut ValidationResult manuelt —
+     * fanges av grunnmurExceptionHandlers og gir 400.
+     *
+     * @return den trimmede e-postadressen hvis gyldig.
+     */
+    fun requireValidEmail(value: String, fieldName: String = "E-post"): String {
+        val trimmed = value.trim()
+        val result = validateEmail(trimmed)
+        if (!result.isValid) throw BadRequestException(result.error ?: "$fieldName er ugyldig")
+        return trimmed
+    }
+
+    /**
+     * Kaster BadRequestException hvis verdien er null eller blank.
+     *
+     * @return den trimmede verdien hvis ikke blank.
+     */
+    fun requireNonBlank(value: String?, fieldName: String): String {
+        if (value.isNullOrBlank()) throw BadRequestException("$fieldName kan ikke vaere tomt")
+        return value.trim()
+    }
+
+    /**
+     * Kaster BadRequestException hvis verdien er lengre enn maxLength.
+     *
+     * @return verdien uendret hvis innenfor lengdegrensen.
+     */
+    fun requireMaxLength(value: String, fieldName: String, maxLength: Int): String {
+        if (value.length > maxLength) {
+            throw BadRequestException("$fieldName kan ikke vaere lengre enn $maxLength tegn")
+        }
+        return value
+    }
+
+    /**
      * Validerer telefonnummer (valgfritt felt).
      *
      * @param strict Hvis true, krever norsk 8-siffer med forste siffer 2-9. Default: true.

--- a/src/test/kotlin/no/grunnmur/ValidatorsTest.kt
+++ b/src/test/kotlin/no/grunnmur/ValidatorsTest.kt
@@ -44,6 +44,53 @@ class ValidatorsTest {
             assertFalse(Validators.isValidEmail("a@b"))
             assertFalse(Validators.isValidEmail("user@localhost"))
         }
+
+        @Test
+        fun `requireValidEmail returnerer trimmet verdi for gyldig e-post`() {
+            assertEquals("test@example.com", Validators.requireValidEmail("  test@example.com  "))
+        }
+
+        @Test
+        fun `requireValidEmail kaster BadRequestException for ugyldig e-post`() {
+            val ex = assertThrows(BadRequestException::class.java) {
+                Validators.requireValidEmail("ikke-epost")
+            }
+            assertEquals("Ugyldig e-postformat", ex.message)
+        }
+
+        @Test
+        fun `requireValidEmail kaster BadRequestException for single-label domene`() {
+            assertThrows(BadRequestException::class.java) {
+                Validators.requireValidEmail("user@localhost")
+            }
+        }
+    }
+
+    @Nested
+    inner class RequireHelpers {
+        @Test
+        fun `requireNonBlank returnerer trimmet verdi`() {
+            assertEquals("Ola", Validators.requireNonBlank("  Ola  ", "Navn"))
+        }
+
+        @Test
+        fun `requireNonBlank kaster BadRequestException for null og blank`() {
+            assertThrows(BadRequestException::class.java) { Validators.requireNonBlank(null, "Navn") }
+            assertThrows(BadRequestException::class.java) { Validators.requireNonBlank("   ", "Navn") }
+        }
+
+        @Test
+        fun `requireMaxLength godtar verdi innenfor grensen`() {
+            assertEquals("abc", Validators.requireMaxLength("abc", "Felt", maxLength = 3))
+        }
+
+        @Test
+        fun `requireMaxLength kaster BadRequestException naar for lang`() {
+            val ex = assertThrows(BadRequestException::class.java) {
+                Validators.requireMaxLength("abcd", "Felt", maxLength = 3)
+            }
+            assertTrue(ex.message!!.contains("Felt"))
+        }
     }
 
     @Nested


### PR DESCRIPTION
6810 and smart-casual each roll their own email regex/validation instead
of using grunnmur's Validators, because Validators.validateEmail returns
a ValidationResult that has to be unwrapped manually, while both apps
want throw-style (IllegalArgumentException) that falls straight through
to the 400 handler. Result: the same address can be valid in one app and
invalid in another.

Adds requireValidEmail/requireNonBlank/requireMaxLength, which validate
against the existing canonical Validators regex (single-label domains
rejected) and throw BadRequestException - already mapped to 400 by
grunnmurExceptionHandlers - instead of returning a ValidationResult.

Follow-up (tracked in #264, not done here): migrate 6810's
Validation.kt and smart-casual's ValidationUtils.kt to call these.

Fixes #264
