### PR TITLE
feat: add CSRF/auth cookie issuance helpers to CsrfPlugin

### DIFF
--- a/src/main/kotlin/no/grunnmur/CsrfPlugin.kt
+++ b/src/main/kotlin/no/grunnmur/CsrfPlugin.kt
@@ -5,6 +5,83 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+private const val CSRF_TOKEN_BYTES = 32
+private const val DEFAULT_COOKIE_MAX_AGE = 30 * 24 * 60 * 60 // 30 dager
+
+/**
+ * Genererer et nytt tilfeldig CSRF-token (32 bytes, Base64url uten padding).
+ */
+fun generateCsrfToken(): String {
+    val bytes = ByteArray(CSRF_TOKEN_BYTES)
+    SecureRandom().nextBytes(bytes)
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+}
+
+/**
+ * Setter csrf_token-cookien paa responsen. Ikke httpOnly - maa vaere lesbar fra
+ * JavaScript slik at frontend kan sende tokenet tilbake som X-CSRF-Token-header.
+ *
+ * @param secure Sett `Secure`-flagget (kun sendt over HTTPS). Bruk true i produksjon.
+ * @param devMode Bruker SameSite=Lax i stedet for Strict (kreves for localhost-utvikling paa tvers av porter).
+ * @param maxAge Levetid i sekunder. Default 30 dager (dagens konsensus paa tvers av appene).
+ */
+fun ApplicationCall.setCsrfCookie(
+    token: String,
+    secure: Boolean,
+    devMode: Boolean = false,
+    maxAge: Int = DEFAULT_COOKIE_MAX_AGE
+) {
+    response.cookies.append(
+        Cookie(
+            name = "csrf_token",
+            value = token,
+            httpOnly = false,
+            secure = secure,
+            path = "/",
+            maxAge = maxAge,
+            extensions = mapOf("SameSite" to if (devMode) "Lax" else "Strict")
+        )
+    )
+}
+
+/**
+ * Setter auth_token-cookien (JWT) paa responsen. HttpOnly - utilgjengelig for JavaScript.
+ *
+ * @param secure Sett `Secure`-flagget (kun sendt over HTTPS). Bruk true i produksjon.
+ * @param devMode Bruker SameSite=Lax i stedet for Strict (kreves for localhost-utvikling paa tvers av porter).
+ * @param maxAge Levetid i sekunder. Default 30 dager. Bruk et kortere vindu for midlertidige
+ * tokens (f.eks. under en 2FA-mellomsteg).
+ */
+fun ApplicationCall.setAuthCookie(
+    jwt: String,
+    secure: Boolean,
+    devMode: Boolean = false,
+    maxAge: Int = DEFAULT_COOKIE_MAX_AGE
+) {
+    response.cookies.append(
+        Cookie(
+            name = "auth_token",
+            value = jwt,
+            httpOnly = true,
+            secure = secure,
+            path = "/",
+            maxAge = maxAge,
+            extensions = mapOf("SameSite" to if (devMode) "Lax" else "Strict")
+        )
+    )
+}
+
+/**
+ * Fjerner auth_token- og csrf_token-cookiene (logout). Setter maxAge=0 slik at
+ * nettleseren sletter dem umiddelbart.
+ */
+fun ApplicationCall.clearAuthCookies() {
+    response.cookies.append(Cookie(name = "auth_token", value = "", httpOnly = true, path = "/", maxAge = 0))
+    response.cookies.append(Cookie(name = "csrf_token", value = "", httpOnly = false, path = "/", maxAge = 0))
+}
 
 /**
  * CSRF-beskyttelse plugin for Ktor.

--- a/src/test/kotlin/no/grunnmur/CsrfPluginTest.kt
+++ b/src/test/kotlin/no/grunnmur/CsrfPluginTest.kt
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertContains
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 
 class CsrfPluginTest {
 
@@ -198,6 +200,85 @@ class CsrfPluginTest {
                 header("X-My-CSRF", "token-123")
             }
             assertEquals(HttpStatusCode.OK, response.status)
+        }
+    }
+
+    @Nested
+    inner class CookieHelpers {
+
+        private fun ApplicationTestBuilder.setupCookieApp() {
+            application {
+                routing {
+                    get("/set-csrf") {
+                        call.setCsrfCookie(generateCsrfToken(), secure = true)
+                        call.respondText("OK")
+                    }
+                    get("/set-csrf-dev") {
+                        call.setCsrfCookie("dev-token", secure = false, devMode = true, maxAge = 3600)
+                        call.respondText("OK")
+                    }
+                    get("/set-auth") {
+                        call.setAuthCookie("jwt-abc", secure = true)
+                        call.respondText("OK")
+                    }
+                    get("/clear-auth") {
+                        call.clearAuthCookies()
+                        call.respondText("OK")
+                    }
+                }
+            }
+        }
+
+        @Test
+        fun `generateCsrfToken gir unike tokens av riktig lengde`() {
+            val a = generateCsrfToken()
+            val b = generateCsrfToken()
+            assertNotEquals(a, b)
+            // 32 bytes Base64url uten padding -> 43 tegn
+            assertEquals(43, a.length)
+        }
+
+        @Test
+        fun `setCsrfCookie bruker prod-defaults - Secure, SameSite=Strict, 30 dager`() = testApplication {
+            setupCookieApp()
+            val response = client.get("/set-csrf")
+            val cookie = response.headers.getAll(HttpHeaders.SetCookie)?.firstOrNull { it.startsWith("csrf_token=") }
+            assertNotNull(cookie)
+            assertContains(cookie, "Secure")
+            assertContains(cookie, "SameSite=Strict")
+            assertContains(cookie, "Max-Age=${30 * 24 * 60 * 60}")
+            assert(!cookie.contains("HttpOnly")) { "csrf_token skal vaere lesbar fra JavaScript" }
+        }
+
+        @Test
+        fun `setCsrfCookie i devMode bruker SameSite=Lax og tilpasset maxAge`() = testApplication {
+            setupCookieApp()
+            val response = client.get("/set-csrf-dev")
+            val cookie = response.headers.getAll(HttpHeaders.SetCookie)?.firstOrNull { it.startsWith("csrf_token=") }
+            assertNotNull(cookie)
+            assertContains(cookie, "SameSite=Lax")
+            assertContains(cookie, "Max-Age=3600")
+            assert(!cookie.contains("Secure"))
+        }
+
+        @Test
+        fun `setAuthCookie setter HttpOnly og Secure`() = testApplication {
+            setupCookieApp()
+            val response = client.get("/set-auth")
+            val cookie = response.headers.getAll(HttpHeaders.SetCookie)?.firstOrNull { it.startsWith("auth_token=") }
+            assertNotNull(cookie)
+            assertContains(cookie, "HttpOnly")
+            assertContains(cookie, "Secure")
+            assertContains(cookie, "SameSite=Strict")
+        }
+
+        @Test
+        fun `clearAuthCookies setter maxAge=0 for baade auth_token og csrf_token`() = testApplication {
+            setupCookieApp()
+            val response = client.get("/clear-auth")
+            val cookies = response.headers.getAll(HttpHeaders.SetCookie) ?: emptyList()
+            assertEquals(2, cookies.size)
+            assert(cookies.all { it.contains("Max-Age=0") })
         }
     }
 }


### PR DESCRIPTION
CsrfPlugin only validated CSRF tokens; generating the token and issuing
the csrf_token/auth_token cookies was left to each consumer, and all
three apps copy-pasted an identical verbatim triplet (generateCsrfToken +
setCsrfCookie + the auth_token cookie block in AuthRoutes). 6810 drifted
from the pattern - its csrf_token cookie is missing both `secure` and
`SameSite`, exactly the kind of drift a shared library should prevent.

Adds generateCsrfToken(), ApplicationCall.setCsrfCookie/setAuthCookie
(explicit secure/devMode/maxAge params so callers can't silently omit
the security flags) and clearAuthCookies() for logout. Defaults match
the current three-app consensus: 30 days, SameSite=Strict in prod,
Lax in dev.

Follow-up (tracked in #262, not done here): migrate all four apps to
call these instead of their local copies (6810 gets secure+SameSite
for free; full OTP-login-route consolidation is a separate, larger
follow-up per the issue's scope note).

Fixes #262
