### PR TITLE
Fix #272: docs: GitHubApiException dokumentert med feil HTTP-status (500 istedenfor faktisk 502)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,7 @@ Config: `Config(uploadDir, baseUrl, repo = "", maxFileSize = 2MB, maxImagesPerIs
 - `ForbiddenException(message)` -> 403
 - `RateLimitException(message, retryAfterSeconds?)` -> 429 (med `Retry-After`-header naar tilgjengelig)
 - `AuthenticationException(message)` -> 401
-- `GitHubApiException(message, statusCode?, cause?)` — kastes av GitHubAppAuth og GitHubIssueService ved 4xx/5xx-svar fra GitHub eller parsefeil (statusCode = null)
+- `GitHubApiException(message, statusCode?, cause?)` — kastes av GitHubAppAuth og GitHubIssueService ved 4xx/5xx-svar fra GitHub eller parsefeil (statusCode = null) -> 502
 
 ## Teknisk
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ install(StatusPages) {
 }
 ```
 
-Mapper: `BadRequestException` -> 400, `NotFoundException` -> 404, `ForbiddenException` -> 403, `RateLimitException` -> 429, `AuthenticationException` -> 401, `GitHubApiException` -> 500 (fra GitHub API-feil), `IllegalArgumentException` -> 400, `Throwable` -> 500 (skjuler detaljer i produksjon).
+Mapper: `BadRequestException` -> 400, `NotFoundException` -> 404, `ForbiddenException` -> 403, `RateLimitException` -> 429, `AuthenticationException` -> 401, `GitHubApiException` -> 502 (fra GitHub API-feil), `IllegalArgumentException` -> 400, `Throwable` -> 500 (skjuler detaljer i produksjon).
 
 ---
 
@@ -444,7 +444,7 @@ Typed exceptions som mappes til HTTP-statuskoder via StatusPages:
 | `ForbiddenException` | 403 Forbidden |
 | `RateLimitException` | 429 Too Many Requests |
 | `AuthenticationException` | 401 Unauthorized |
-| `GitHubApiException` | 500 Internal Server Error (fra GitHub API-feil) |
+| `GitHubApiException` | 502 Bad Gateway (fra GitHub API-feil) |
 
 #### TotpModels (`TotpModels.kt`)
 Serialiserbare dataklasser for TOTP-operasjoner:


### PR DESCRIPTION
Fixes #272

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.