### PR TITLE
Fix #273: docs: CsrfPlugin sine nye cookie-hjelpefunksjoner er udokumentert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,29 @@ install(GrunnmurCsrf) {
 }
 ```
 
-Eksporterer: `GrunnmurCsrf` (plugin), `CsrfConfig` (class)
+**Cookie-hjelpefunksjoner:**
+- `generateCsrfToken(): String` — genererer 32-byte Base64url CSRF-token
+- `ApplicationCall.setCsrfCookie(token, secure, devMode = false, maxAge = 30 dager)` — setter csrf_token-cookie (ikke httpOnly)
+- `ApplicationCall.setAuthCookie(jwt, secure, devMode = false, maxAge = 30 dager)` — setter auth_token-cookie (httpOnly)
+- `ApplicationCall.clearAuthCookies()` — fjerner begge cookies (logout)
+
+Eksempel (login/Logout):
+```kotlin
+// Login: sett begge cookies
+post("/api/auth/login") {
+    val jwt = createJwtToken(user)
+    val csrfToken = generateCsrfToken()
+    call.setAuthCookie(jwt, secure = true)
+    call.setCsrfCookie(csrfToken, secure = true)
+}
+
+// Logout: fjern begge cookies
+post("/api/auth/logout") {
+    call.clearAuthCookies()
+}
+```
+
+Eksporterer: `GrunnmurCsrf` (plugin), `CsrfConfig` (class), `generateCsrfToken`, `setCsrfCookie`, `setAuthCookie`, `clearAuthCookies`
 
 #### KeyRateLimiter (`RateLimiter.kt`) — interface
 Felles interface for enkle nøkkel-baserte rate limitere. Implementeres av `RateLimiter` og `CompositeRateLimiter`. `AuthRateLimiter` holdes utenfor da den bruker to nøkler (IP + identifikator).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,31 @@ install(GrunnmurCsrf) {
 }
 ```
 
+**Cookie-hjelpefunksjoner** for standardisert cookie-utstedelse:
+
+| Funksjon | Signatur | Beskrivelse |
+|----------|----------|-------------|
+| `generateCsrfToken` | `(): String` | Genererer 32-byte Base64url CSRF-token |
+| `setCsrfCookie` | `(ApplicationCall).(token: String, secure: Boolean, devMode: Boolean = false, maxAge: Int = 30 dager)` | Setter csrf_token-cookie (ikke httpOnly) |
+| `setAuthCookie` | `(ApplicationCall).(jwt: String, secure: Boolean, devMode: Boolean = false, maxAge: Int = 30 dager)` | Setter auth_token-cookie (httpOnly) |
+| `clearAuthCookies` | `(ApplicationCall).()` | Fjerner begge cookies (logout) |
+
+Eksempel (login/logout):
+```kotlin
+// Login
+post("/api/auth/login") {
+    val jwt = createJwtToken(user)
+    val csrfToken = generateCsrfToken()
+    call.setAuthCookie(jwt, secure = true)
+    call.setCsrfCookie(csrfToken, secure = true)
+}
+
+// Logout
+post("/api/auth/logout") {
+    call.clearAuthCookies()
+}
+```
+
 - **`GrunnmurCsrf`** — Ktor ApplicationPlugin (installeres med `install()`)
 - **`CsrfConfig`** — Konfigurasjon: `exemptPaths`, `authCookieName`, `csrfCookieName`, `csrfHeaderName`
 


### PR DESCRIPTION
Fixes #273

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.