### PR TITLE
Fix #279: docs: vinforalle gjenoppstått som konsument av grunnmur — ikke listet i README

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,3 +526,4 @@ services:
 - [styreportal](https://github.com/TommySkogstad/styreportal)
 - [smart-casual](https://github.com/TommySkogstad/smart-casual)
 - [maskemester](https://github.com/TommySkogstad/maskemester)
+- [vinforalle](https://github.com/TommySkogstad/vinforalle)


### PR DESCRIPTION
Fixes #279

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.