### PR TITLE
docs: Update Kotlin version to 2.4.10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,7 @@ Config: `Config(uploadDir, baseUrl, repo = "", maxFileSize = 2MB, maxImagesPerIs
 
 ## Teknisk
 
-- **Kotlin**: 2.4.0
+- **Kotlin**: 2.4.10
 - **Ktor**: 3.5.1 (compileOnly — Server + Client CIO)
 - **Exposed**: 1.3.1 (compileOnly)
 - **kotlinx-serialization-json**: 1.11.0 (compileOnly)

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ services:
 
 ## Versjoner
 
-- Kotlin 2.4.0, Ktor 3.5.1 (Server + Client CIO), Exposed 1.3.1, JVM 25
+- Kotlin 2.4.10, Ktor 3.5.1 (Server + Client CIO), Exposed 1.3.1, JVM 25
 - kotlinx-serialization-json 1.11.0, Jakarta Mail 2.1.5, Flyway 11.19.1
 - kotlin-onetimepassword 2.4.1, SLF4J 2.0.18
 - Testcontainers 1.21.4, PostgreSQL JDBC 42.7.13 (integrasjonstester)


### PR DESCRIPTION
Fixes #286

## Summary
Updates documentation to match actual Kotlin version in build.gradle.kts.

**Changes:**
- CLAUDE.md § Teknisk: Kotlin 2.4.0 → 2.4.10
- README.md § Versjoner: Kotlin 2.4.0 → 2.4.10

**Reason:** Commit 6224e73 (deps: bump jvm from 2.4.0 to 2.4.10) updated the build configuration but documentation was not synced.

**Note:** build.gradle.kts line 3 shows kotlin("plugin.serialization") version "2.4.0" which differs from jvm-plugin 2.4.10 — this is a separate internal inconsistency to address, outside the scope of this docs fix.