### PR TITLE
docs: Add vinforalle to grunnmur usage list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # grunnmur
 
 Felles Kotlin-bibliotek for alle Ktor-apper i portefoljen.
-Brukes av biologportal, 6810, styreportal, smart-casual og maskemester.
+Brukes av biologportal, 6810, styreportal, smart-casual, maskemester og vinforalle.
 
 ## Komplett modulreferanse (23 filer, 18 moduler)
 


### PR DESCRIPTION
Fixes #287

Updates CLAUDE.md line 4 to include vinforalle in the list of apps using grunnmur, consistent with the README.md update from #279.