### PR TITLE
Fix #301: Update Ktor and Exposed version numbers in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,8 +337,8 @@ Config: `Config(uploadDir, baseUrl, repo = "", maxFileSize = 2MB, maxImagesPerIs
 ## Teknisk
 
 - **Kotlin**: 2.4.10
-- **Ktor**: 3.5.1 (compileOnly — Server + Client CIO)
-- **Exposed**: 1.3.1 (compileOnly)
+- **Ktor**: 3.5.2 (compileOnly — Server + Client CIO)
+- **Exposed**: 1.4.0 (compileOnly)
 - **kotlinx-serialization-json**: 1.11.0 (compileOnly)
 - **Jakarta Mail**: 2.1.5 (compileOnly)
 - **Flyway**: 11.19.1 (compileOnly — pinnet pga bug i 11.20.3/12.x)

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ services:
 
 ## Versjoner
 
-- Kotlin 2.4.10, Ktor 3.5.1 (Server + Client CIO), Exposed 1.3.1, JVM 25
+- Kotlin 2.4.10, Ktor 3.5.2 (Server + Client CIO), Exposed 1.4.0, JVM 25
 - kotlinx-serialization-json 1.11.0, Jakarta Mail 2.1.5, Flyway 11.19.1
 - kotlin-onetimepassword 2.4.1, SLF4J 2.0.18
 - Testcontainers 1.21.4, PostgreSQL JDBC 42.7.13 (integrasjonstester)


### PR DESCRIPTION
Fixes #301

Updates version numbers in CLAUDE.md and README.md to match build.gradle.kts:
- Ktor 3.5.1 → 3.5.2
- Exposed 1.3.1 → 1.4.0

These versions were bumped by dependabot but documentation was not updated
simultaneously, causing version drift between build.gradle.kts and
documentation.