### PR TITLE
Fix #303: oppdater konsumentoversikt og GitHub App-exception-mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ One-Time Password med SHA-256. Dev-modus: kode "123456" fungerer alltid. Lagring
 `grunnmurExceptionHandlers(isProduction: Boolean = System.getenv("KTOR_ENV") == "production")` — mapper grunnmur-exceptions til HTTP-statuskoder:
 - BadRequestException -> 400, NotFoundException -> 404, ForbiddenException -> 403
 - RateLimitException -> 429 (med `Retry-After`-header ved tilgjengelig), AuthenticationException -> 401
-- IllegalArgumentException -> 400, Throwable -> 500 (skjuler detaljer i prod når `isProduction=true`, viser exception-melding i dev)
+- GitHubApiException -> 502, IllegalArgumentException -> 400, Throwable -> 500 (skjuler detaljer i prod når `isProduction=true`, viser exception-melding i dev)
 
 ### Database
 
@@ -443,7 +443,7 @@ Apper sjekker ut grunnmur med `grunnmur-access` GitHub App (App ID `GRUNNMUR_APP
 
 ## Versjonsstrategi
 
-`build.gradle.kts` har `version = "1.0.0"` hardkodet med hensikt. Appene (biologportal, 6810, styreportal) konsumerer grunnmur via Gradle composite build (`includeBuild`) — ikke via Maven-koordinater. Sporbarhet skjer via git commit-hash, ikke versjonsnummer.
+`build.gradle.kts` har `version = "1.0.0"` hardkodet med hensikt. Appene (biologportal, 6810, styreportal, smart-casual, maskemester og vinforalle) konsumerer grunnmur via Gradle composite build (`includeBuild`) — ikke via Maven-koordinater. Sporbarhet skjer via git commit-hash, ikke versjonsnummer.
 
 `publishing`-blokken i `build.gradle.kts` eksisterer for fremtidig publisering til GitHub Packages, men er ikke i rutinemessig bruk. Versjonen bumpes kun manuelt ved breaking changes — ingen automatisk bump, ingen SNAPSHOT-konvensjon, ingen CHANGELOG.
 
@@ -455,7 +455,7 @@ Inntil da holdes versjonen fast. Dette er en bevisst avgjoerelse, ikke en glemt 
 
 ## Viktig
 
-- Ved Dependabot-oppgraderinger: oppgrader grunnmur FOERST, deretter alle 4 apper til samme versjoner
+- Ved Dependabot-oppgraderinger: oppgrader grunnmur FOERST, deretter alle 6 apper til samme versjoner
 - Kotlin metadata 2.4 kan ikke leses av 2.1-kompilator (NoClassDefFoundError)
 - Exposed-versjoner maa vaere identiske mellom grunnmur og apper
 - **Kryssrepo-avhengigheter**: Grunnmur er et delt bibliotek. Naar ny funksjonalitet legges til, opprett GitHub issue paa grunnmur FOERST, deretter issues paa alle apper som skal bruke den nye modulen med `Blokkert av: TommySkogstad/grunnmur#nummer` i issue-bodyen. Issue-triage haandterer avhengighetsrekkefoeolgen automatisk — blokkerte issues venter til grunnmur-issuen er lukket.


### PR DESCRIPTION
Fixes #303

**Hva ble gjort**:
- Versjonsstrategi-seksjon: Oppdater konsumentliste fra 3 til 6 apper (biologportal, 6810, styreportal, smart-casual, maskemester, vinforalle)
- Viktig-seksjon: Korriger 'alle 4 apper' til 'alle 6 apper' for Dependabot-oppgraderinger
- StatusPagesConfig oppsummering: Legg til GitHubApiException -> 502 i exception-mappingen

Alle endringer er dokumentasjon-kun, ingen kodeendringer.