### PR TITLE
Fix #308: Update Exposed version in docs (1.4.0 → 1.5.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,7 +338,7 @@ Config: `Config(uploadDir, baseUrl, repo = "", maxFileSize = 2MB, maxImagesPerIs
 
 - **Kotlin**: 2.4.10
 - **Ktor**: 3.5.2 (compileOnly — Server + Client CIO)
-- **Exposed**: 1.4.0 (compileOnly)
+- **Exposed**: 1.5.0 (compileOnly)
 - **kotlinx-serialization-json**: 1.11.0 (compileOnly)
 - **Jakarta Mail**: 2.1.5 (compileOnly)
 - **Flyway**: 11.19.1 (compileOnly — pinnet pga bug i 11.20.3/12.x)

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ services:
 
 ## Versjoner
 
-- Kotlin 2.4.10, Ktor 3.5.2 (Server + Client CIO), Exposed 1.4.0, JVM 25
+- Kotlin 2.4.10, Ktor 3.5.2 (Server + Client CIO), Exposed 1.5.0, JVM 25
 - kotlinx-serialization-json 1.11.0, Jakarta Mail 2.1.5, Flyway 11.19.1
 - kotlin-onetimepassword 2.4.1, SLF4J 2.0.18
 - Testcontainers 1.21.4, PostgreSQL JDBC 42.7.13 (integrasjonstester)


### PR DESCRIPTION
Fixes #308

Align documentation with build.gradle.kts which was updated to Exposed 1.5.0 in dependabot PR e872e17.

- CLAUDE.md linje 341: 1.4.0 → 1.5.0
- README.md linje 515: 1.4.0 → 1.5.0